### PR TITLE
avoid the user's init file

### DIFF
--- a/split_definitions.py
+++ b/split_definitions.py
@@ -35,7 +35,7 @@ def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=D
     (stdout, stderr) = p.communicate()
     if '-time' not in stdout:
         return fallback()
-    p = Popen([coqtop, '-emacs', '-time'] + list(coqtop_args), stdout=PIPE, stderr=STDOUT, stdin=PIPE)
+    p = Popen([coqtop, '-emacs', '-q', '-time'] + list(coqtop_args), stdout=PIPE, stderr=STDOUT, stdin=PIPE)
     split_reg = re.compile(r'Chars ([0-9]+) - ([0-9]+) [^\s]+ (.*?)<prompt>([^<]*?) < ([0-9]+) ([^<]*?) ([0-9]+) < ([^<]*?)</prompt>'.replace(' ', r'\s*'),
                            flags=re.DOTALL)
     defined_reg = re.compile(r'^([^\s]+) is (?:defined|assumed)$', re.MULTILINE)


### PR DESCRIPTION
... because coqc reports on its statements when the -time option is used.

This resolves issue #12.