### PR TITLE
make make_reg_string work when the error output contains unicode characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
  - yes "y" | examples/run-example-08-3.sh
  - yes "y" | examples/run-example-09.sh
 # - yes "y" | examples/run-example-10.sh # needs Coq 8.5
+- yes "y" | examples/run-example-11.sh

--- a/diagnose_error.py
+++ b/diagnose_error.py
@@ -46,7 +46,7 @@ def make_reg_string(output):
 
     Precondition: has_error(output)
     """
-    error_string = get_error_string(output).strip()
+    error_string = get_error_string(output).strip().decode('utf-8')
     if 'Universe inconsistency' in error_string:
         re_string = re.sub(r'(Universe\\ inconsistency.*) because(.|\n)*',
                            r'\1 because.*',
@@ -73,7 +73,7 @@ def make_reg_string(output):
         re_string = re.sub(r'[\d]+',
                            r'[\d]+',
                            re_string)
-    return DEFAULT_ERROR_REG_STRING_GENERIC % re_string
+    return (DEFAULT_ERROR_REG_STRING_GENERIC % re_string).encode('utf-8')
 
 TIMEOUT = None
 

--- a/examples/example_11/example_11.v
+++ b/examples/example_11/example_11.v
@@ -1,0 +1,1 @@
+Definition v := φ.

--- a/examples/run-example-11.sh
+++ b/examples/run-example-11.sh
@@ -18,13 +18,3 @@ then
 fi
 
 python ../../find-bug.py example_11.v bug_11.v || exit $?
-EXPECTED='^(\* File reduced by coq-bug-finder from original input, then from [0-9]\+ lines to [0-9]\+ lines, then from [0-9]\+ lines to [0-9]\+ lines, then from [0-9]\+ lines to [0-9]\+ lines \*)$'
-LINES="$(grep -c "$EXPECTED" bug_10.v)"
-if [ "$LINES" -ne 1 ]
-then
-    echo "Expected a string matching:"
-    echo "$EXPECTED"
-    cat bug_10.v
-    exit 1
-fi
-exit 0

--- a/examples/run-example-11.sh
+++ b/examples/run-example-11.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR/example_11"
+PS4='$ '
+set -x
+EXPECTED_ERROR="The reference φ was not found in the current environment."
+ACTUAL_PRE="$(echo "y" | python ../../find-bug.py example_11.v bug_11.v 2>&1)"
+if [ "$(echo "$ACTUAL_PRE" | grep -c "$EXPECTED_ERROR")" -lt 1 ]
+then
+    echo "Expected a string matching:"
+    echo "$EXPECTED_ERROR"
+    echo
+    echo
+    echo
+    echo "Actual:"
+    echo "$ACTUAL_PRE"
+    exit 1
+fi
+
+python ../../find-bug.py example_11.v bug_11.v || exit $?
+EXPECTED='^(\* File reduced by coq-bug-finder from original input, then from [0-9]\+ lines to [0-9]\+ lines, then from [0-9]\+ lines to [0-9]\+ lines, then from [0-9]\+ lines to [0-9]\+ lines \*)$'
+LINES="$(grep -c "$EXPECTED" bug_10.v)"
+if [ "$LINES" -ne 1 ]
+then
+    echo "Expected a string matching:"
+    echo "$EXPECTED"
+    cat bug_10.v
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Fixes #19.

This is the lazy solution, not converting the entire program to properly use unicode everywhere - hence the string is encoded again before being returned. If this is not done, every time this string is printed, it would try to encode it as `'ascii'` which does not work.