### PR TITLE
fix printing regexp with newlines to the user

### DIFF
--- a/examples/run-example-12.sh
+++ b/examples/run-example-12.sh
@@ -47,7 +47,7 @@ The expression "Set" of type "Type"
 cannot be applied to the term
  "Set" : "Type"
 '\.
-The corresponding regular expression is 'File "\[^"\]+", line (\[0-9\]+), characters \[0-9-\]+:\\\\n(Error\\\\:\\\\ Illegal\\\\ application\\\\ \\\\(Non\\\\-functional\\\\ construction\\\\)\\\\:\\\\ \\\\\\\\nThe\\\\ expression\\\\ \\\\"Set\\\\"\\\\ of\\\\ type\\\\ \\\\"Type\\\\"\\\\\\\\ncannot\\\\ be\\\\ applied\\\\ to\\\\ the\\\\ term\\\\\\\\n\\\\ \\\\"Set\\\\"\\\\ \\\\:\\\\ \\\\"Type\\\\")'\.
+The corresponding regular expression is 'File "\[^"\]+", line (\[0-9\]+), characters \[0-9-\]+:\\\\n(Error\\\\:\\\\ Illegal\\\\ application\\\\ \\\\(Non\\\\-functional\\\\ construction\\\\)\\\\:\\\\ \\\\nThe\\\\ expression\\\\ \\\\"Set\\\\"\\\\ of\\\\ type\\\\ \\\\"Type\\\\"\\\\ncannot\\\\ be\\\\ applied\\\\ to\\\\ the\\\\ term\\\\n\\\\ \\\\"Set\\\\"\\\\ \\\\:\\\\ \\\\"Type\\\\")'\.
 Is this correct? \[(y)es/(n)o\] Traceback (most recent call last):
   File "\.\./\.\./find-bug\.py", line [0-9]\+, in <module>
     env\['error_reg_string'\] = get_error_reg_string(output_file_name, \*\*env)

--- a/find-bug.py
+++ b/find-bug.py
@@ -238,7 +238,7 @@ def get_error_reg_string(output_file_name, **kwargs):
         if diagnose_error.has_error(output):
             error_string = diagnose_error.get_error_string(output)
             error_reg_string = diagnose_error.make_reg_string(output)
-            print("\nI think the error is '%s'.\nThe corresponding regular expression is '%s'." % (error_string, error_reg_string.replace('\n', '\\n')))
+            print("\nI think the error is '%s'.\nThe corresponding regular expression is '%s'." % (error_string, error_reg_string.replace('\\\n', '\\n').replace('\n', '\\n')))
             result = ''
             while result not in ('y', 'n', 'yes', 'no'):
                 result = raw_input('Is this correct? [(y)es/(n)o] ').lower().strip()


### PR DESCRIPTION
Fixes #22 

The trouble was that the code actually emitted `\` followed by a newline, in an attempt to make sure that the newline is properly escaped. Make the output function deal with that.