### PR TITLE
Logging: different verbosities for different files

### DIFF
--- a/absolutize-imports.py
+++ b/absolutize-imports.py
@@ -29,7 +29,7 @@ add_logging_arguments(parser)
 
 
 def absolutize_imports(filename, **kwargs):
-    if kwargs['verbose']: kwargs['log']('Processing %s...' % filename)
+    kwargs['log']('Processing %s...' % filename)
     absolutized_contents = get_file(filename, update_globs=True, **kwargs)
     if kwargs['inplace']:
         do_backup = kwargs['suffix'] is not None and len(kwargs['suffix']) > 0
@@ -45,7 +45,6 @@ if __name__ == '__main__':
         else:
             return prog
     env = {
-        'verbose': args.verbose,
         'log': args.log,
         'coqc': prepend_coqbin(args.coqc),
         'inplace': args.suffix != '', # it's None if they passed no argument, and '' if they didn't pass -i

--- a/admit_abstract.py
+++ b/admit_abstract.py
@@ -2,13 +2,13 @@ import re
 
 __all__ = ["transform_abstract_to_admit"]
 
-def DEFAULT_LOG(text):
-    print(text)
+def DEFAULT_LOG(text, level=1):
+    if level <= 1: print(text)
 
 TERM_CHAR = r"[\w']"
 ABSTRACT_NO_PARENS_DOT = re.compile(r"(^\s*|\.\s+|;\s*)abstract\s+(?:[^\(\);\.]|\.%s)+(?=\.\s|\.$)" % TERM_CHAR, re.MULTILINE)
 
-def transform_abstract_to_admit_statement(statement, agressive=False, verbose=1, log=DEFAULT_LOG):
+def transform_abstract_to_admit_statement(statement, agressive=False, log=DEFAULT_LOG):
     # remove the unparenthesized ones
     statement = ABSTRACT_NO_PARENS_DOT.sub(r'\1admit', statement)
 
@@ -22,25 +22,25 @@ def transform_abstract_to_admit_statement(statement, agressive=False, verbose=1,
     rtn = []
     cur = []
     for term in re.split('([;\.\(\)])', statement):
-        if verbose >= 3:
-            log('in_abstract: %d; abstract_paren_level: %d; agressive: %d; ready_for_abstract: %d;\n^term: %s' %
-                (in_abstract, abstract_paren_level, agressive, ready_for_abstract, term))
+        log('in_abstract: %d; abstract_paren_level: %d; agressive: %d; ready_for_abstract: %d;\n^term: %s' %
+            (in_abstract, abstract_paren_level, agressive, ready_for_abstract, term),
+            level=3)
         if in_abstract:
             if abstract_paren_level == 0 and term in tuple(';.'):
                 if term == ';':
                     if agressive:
                         rtn.append(' admit;')
-                        if verbose >= 3: log("Appending ' admit;' to rtn")
+                        log("Appending ' admit;' to rtn", level=3)
                     else:
                         cur.append(term)
                         rtn.append(''.join(cur))
-                        if verbose >= 3: log("Appending %s to rtn" % repr(''.join(cur)))
+                        log("Appending %s to rtn" % repr(''.join(cur)), level=3)
                 else:
-                    if verbose >= 3: log("Appending ' admit.' to rtn")
+                    log("Appending ' admit.' to rtn", level=3)
                     rtn.append(' admit.')
                 in_abstract = False
                 cur = []
-                if verbose >= 3: log("Setting in_abstract to false and emptying cur")
+                log("Setting in_abstract to false and emptying cur", level=3)
             elif abstract_paren_level < 0:
                 log('Warning: abstract_paren_level messed up on statement %s' % repr(statement))
                 in_abstract = False
@@ -48,40 +48,40 @@ def transform_abstract_to_admit_statement(statement, agressive=False, verbose=1,
                 rtn.append(''.join(cur))
                 cur = []
                 abstract_paren_level = 0
-                if verbose >= 3: log("Setting in_abstract to false, abstract_paren_level to 0, emptying cur, and\nappending %s to rtn" %
-                                     repr(''.join(cur)))
+                log("Setting in_abstract to false, abstract_paren_level to 0, emptying cur, and\nappending %s to rtn" %
+                    repr(''.join(cur)), level=3)
             else:
                 if term == '(':
                     abstract_paren_level += 1
                 elif term == ')':
                     abstract_paren_level -= 1
                 cur.append(term)
-                if verbose >= 3: log("Setting abstract_paren_level to %d and\nappending %s to cur" % (abstract_paren_level, repr(term)))
+                log("Setting abstract_paren_level to %d and\nappending %s to cur" % (abstract_paren_level, repr(term)), level=3)
         else:
             if ready_for_abstract and term.strip() == 'abstract':
                 cur.append(term)
                 in_abstract = True
-                if verbose >= 3: log("Found %s (appending to cur), now in_abstract" % repr(term))
+                log("Found %s (appending to cur), now in_abstract" % repr(term), level=3)
                 if abstract_paren_level != 0:
                     log('Warning: abstract_paren_level messed up before abstract on statement %s' % repr(statement))
                     abstract_paren_level = 0
             else:
                 if term in tuple('.;'):
-                    if verbose >= 3: log("Found %s (appending to rtn), ready for abstract" % repr(term))
+                    log("Found %s (appending to rtn), ready for abstract" % repr(term), level=3)
                     ready_for_abstract = True
                 elif term.strip():
-                    if verbose >= 3: log("Found %s (appending to rtn), not ready for abstract" % repr(term))
+                    log("Found %s (appending to rtn), not ready for abstract" % repr(term), level=3)
                     ready_for_abstract = False
                 rtn.append(term)
-    if verbose >= 3: log("Done.  Appending %s to rtn." % repr(''.join(cur)))
+    log("Done.  Appending %s to rtn." % repr(''.join(cur)), level=3)
     rtn.append(''.join(cur))
 
     return ''.join(rtn)
 
-def transform_abstract_to_admit(cur_definition, rest_definitions, agressive=False, verbose=1, log=DEFAULT_LOG):
+def transform_abstract_to_admit(cur_definition, rest_definitions, **kwargs):
     # shallow copy
     cur_definition = dict(cur_definition)
-    cur_definition['statements'] = tuple(transform_abstract_to_admit_statement(i, agressive=agressive, verbose=verbose, log=log)
+    cur_definition['statements'] = tuple(transform_abstract_to_admit_statement(i, **kwargs)
                                          for i in cur_definition['statements'])
     cur_definition['statement'] = '\n'.join(cur_definition['statements'])
     return cur_definition

--- a/binding_util.py
+++ b/binding_util.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os
 from coq_version import group_coq_args
-from custom_arguments import DEFAULT_LOG, DEFAULT_VERBOSITY
+from custom_arguments import DEFAULT_LOG
 
 __all__ = ["has_dir_binding", "deduplicate_trailing_dir_bindings", "process_maybe_list"]
 
@@ -24,10 +24,10 @@ def deduplicate_trailing_dir_bindings(args, coqc_help, coq_accepts_top, file_nam
             ret.extend(binding)
     return tuple(ret)
 
-def process_maybe_list(ls, log=DEFAULT_LOG, verbose=DEFAULT_VERBOSITY):
+def process_maybe_list(ls, log=DEFAULT_LOG):
     if ls is None: return tuple()
     if isinstance(ls, str): return tuple([ls])
     if isinstance(ls, tuple): return ls
     if isinstance(ls, list): return tuple(ls)
-    if verbose >= 1: log("Unknown type '%s' of list '%s'" % (str(type(ls)), repr(ls)))
+    log("Unknown type '%s' of list '%s'" % (str(type(ls)), repr(ls)))
     return tuple(ls)

--- a/coq_version.py
+++ b/coq_version.py
@@ -14,8 +14,7 @@ def get_coqc_version_helper(coqc):
     return util.normalize_newlines(util.s(stdout).replace('The Coq Proof Assistant, version ', '')).replace('\n', ' ').strip()
 
 def get_coqc_version(coqc_prog, **kwargs):
-    if kwargs['verbose'] >= 2:
-        kwargs['log']('Running command: "%s"' % '" "'.join([coqc_prog, "-q", "-v"]))
+    kwargs['log']('Running command: "%s"' % '" "'.join([coqc_prog, "-q", "-v"]), level=2)
     return get_coqc_version_helper(coqc_prog)
 
 @memoize
@@ -25,8 +24,7 @@ def get_coqc_config_helper(coqc):
     return util.normalize_newlines(util.s(stdout)).strip()
 
 def get_coqc_config(coqc_prog, **kwargs):
-    if kwargs['verbose'] >= 2:
-        kwargs['log']('Running command: "%s"' % '" "'.join([coqc_prog, "-q", "-config"]))
+    kwargs['log']('Running command: "%s"' % '" "'.join([coqc_prog, "-q", "-config"]), level=2)
     return get_coqc_config_helper(coqc_prog)
 
 def get_coqc_coqlib(coqc_prog, **kwargs):
@@ -39,8 +37,7 @@ def get_coqc_help_helper(coqc):
     return util.s(stdout).strip()
 
 def get_coqc_help(coqc_prog, **kwargs):
-    if kwargs['verbose'] >= 2:
-        kwargs['log']('Running command: "%s"' % '" "'.join([coqc_prog, "-q", "--help"]))
+    kwargs['log']('Running command: "%s"' % '" "'.join([coqc_prog, "-q", "--help"]), level=2)
     return get_coqc_help_helper(coqc_prog)
 
 @memoize
@@ -50,8 +47,7 @@ def get_coqtop_version_helper(coqtop):
     return util.normalize_newlines(util.s(stdout).replace('Welcome to Coq ', '').replace('Skipping rcfile loading.', '')).replace('\n', ' ').strip()
 
 def get_coqtop_version(coqtop_prog, **kwargs):
-    if kwargs['verbose'] >= 2:
-        kwargs['log']('Running command: "%s"' % '" "'.join([coqtop_prog, "-q", "-v"]))
+    kwargs['log']('Running command: "%s"' % '" "'.join([coqtop_prog, "-q", "-v"]), level=2)
     return get_coqtop_version_helper(coqtop_prog)
 
 @memoize

--- a/examples/example_24/expected/run.log
+++ b/examples/example_24/expected/run.log
@@ -5,7 +5,6 @@ getting C.glob
 getting D.glob
 getting AA.v
 getting AA.glob
-The timeout for coqc has been set to: 3
 Running coq on initial contents...
 Successful change
 Saving final version of AA.v...

--- a/examples/run-example-00.sh
+++ b/examples/run-example-00.sh
@@ -57,6 +57,7 @@ Now, I will attempt to coq the file, and find the error\.\.\.
 Coqing the file (bug_[0-9]\+\.v)\.\.\.
 
 Running command: "coqc"\( "-w" "-deprecated-native-compiler-option"\)\? "-nois" "-R" "\." "Top"\( "-top" "example_[0-9]\+"\)\?\( "-native-compiler" "ondemand"\)\? "/tmp/tmp[A-Za-z0-9_]\+\.v" "-q"
+
 The timeout for coqc has been set to: 3
 
 This file produces the following output when Coq'ed:

--- a/find-bug.py
+++ b/find-bug.py
@@ -13,7 +13,7 @@ from admit_abstract import transform_abstract_to_admit
 from import_util import lib_of_filename, clear_libimport_cache, IMPORT_ABSOLUTIZE_TUPLE, ALL_ABSOLUTIZE_TUPLE
 from memoize import memoize
 from coq_version import get_coqc_version, get_coqtop_version, get_coqc_help, get_coq_accepts_top, get_coq_native_compiler_ondemand_fragment, group_coq_args, get_ltac_support_snippet, get_coqc_coqlib
-from custom_arguments import add_libname_arguments, add_passing_libname_arguments, update_env_with_libnames, update_env_with_coqpath_folders, add_logging_arguments, process_logging_arguments, DEFAULT_LOG, DEFAULT_VERBOSITY
+from custom_arguments import add_libname_arguments, add_passing_libname_arguments, update_env_with_libnames, update_env_with_coqpath_folders, add_logging_arguments, process_logging_arguments, DEFAULT_LOG, LOG_ALWAYS
 from binding_util import has_dir_binding, deduplicate_trailing_dir_bindings, process_maybe_list
 from file_util import clean_v_file, read_from_file, write_to_file, restore_file
 from util import yes_no_prompt, PY3
@@ -202,14 +202,14 @@ def get_error_reg_string_of_output(output, **kwargs):
     if diagnose_error.has_error(output):
         error_string = diagnose_error.get_error_string(output)
         error_reg_string = diagnose_error.make_reg_string(output, strict_whitespace=kwargs['strict_whitespace'])
-        kwargs['log']("\nI think the error is '%s'.\nThe corresponding regular expression is '%s'.\n" % (error_string, error_reg_string.replace('\\\n', '\\n').replace('\n', '\\n')), force_stdout=True)
+        kwargs['log']("\nI think the error is '%s'.\nThe corresponding regular expression is '%s'.\n" % (error_string, error_reg_string.replace('\\\n', '\\n').replace('\n', '\\n')), force_stdout=True, level=LOG_ALWAYS)
         result = ''
         while result not in ('y', 'n', 'yes', 'no'):
             result = ask('Is this correct? [(y)es/(n)o] ', **kwargs).lower().strip()
         if result in ('no', 'n'):
             error_reg_string = ''
     else:
-        kwargs['log']('\nThe current state of the file does not have a recognizable error.')
+        kwargs['log']('\nThe current state of the file does not have a recognizable error.', level=LOG_ALWAYS)
 
     if error_reg_string == '':
         success = False
@@ -218,7 +218,7 @@ def get_error_reg_string_of_output(output, **kwargs):
             try:
                 re.compile(error_reg_string)
             except Exception as e:
-                kwargs['log']('\nThat regular expression does not compile: %s' % e, force_stdout=True)
+                kwargs['log']('\nThat regular expression does not compile: %s' % e, force_stdout=True, level=LOG_ALWAYS)
                 success = False
             else:
                 success = True
@@ -227,11 +227,11 @@ def get_error_reg_string_of_output(output, **kwargs):
            and (not re.search(error_reg_string, output)
                 or len(re.search(error_reg_string, output).groups()) != 2)):
         if not re.search(error_reg_string, output):
-            kwargs['log']('\nThe given regular expression does not match the output.', force_stdout=True)
+            kwargs['log']('\nThe given regular expression does not match the output.', force_stdout=True, level=LOG_ALWAYS)
         elif len(re.search(error_reg_string, output).groups()) != 2:
-            kwargs['log']('\nThe given regular expression does not have two groups.', force_stdout=True)
-            kwargs['log']('It must first have one integer group which matches on the line number,', force_stdout=True)
-            kwargs['log']('and second a group which matches on the error string.', force_stdout=True)
+            kwargs['log']('\nThe given regular expression does not have two groups.', force_stdout=True, level=LOG_ALWAYS)
+            kwargs['log']('It must first have one integer group which matches on the line number,', force_stdout=True, level=LOG_ALWAYS)
+            kwargs['log']('and second a group which matches on the error string.', force_stdout=True, level=LOG_ALWAYS)
         error_reg_string = raw_input('Please enter a valid regular expression which matches on the output.  Leave blank to re-coq the file (%s).\n'
                                      % output_file_name)
     return error_reg_string
@@ -239,13 +239,13 @@ def get_error_reg_string_of_output(output, **kwargs):
 def get_error_reg_string(output_file_name, **kwargs):
     error_reg_string = ''
     while error_reg_string == '':
-        if kwargs['verbose']: kwargs['log']('\nCoqing the file (%s)...' % output_file_name)
+        kwargs['log']('\nCoqing the file (%s)...' % output_file_name)
         contents = read_from_file(output_file_name)
         diagnose_error.reset_timeout()
-        if kwargs['verbose'] > 2: kwargs['log']('\nContents:\n\n%s\n\n' % contents)
+        kwargs['log']('\nContents:\n\n%s\n\n' % contents, level=3)
         output, cmds, retcode, runtime = diagnose_error.get_coq_output(kwargs['coqc'], kwargs['coqc_args'], contents, kwargs['timeout'], is_coqtop=kwargs['coqc_is_coqtop'], verbose_base=1, **kwargs)
         result = ''
-        kwargs['log']("\nThis file produces the following output when Coq'ed:\n%s" % output, force_stdout=True)
+        kwargs['log']("\nThis file produces the following output when Coq'ed:\n%s" % output, force_stdout=True, level=LOG_ALWAYS)
         while result not in ('y', 'n', 'yes', 'no'):
             result = ask('Does this output display the correct error? [(y)es/(n)o] ', **kwargs).lower().strip()
         if result in ('n', 'no'):
@@ -276,7 +276,7 @@ def unescape_coq_prog_args(coq_prog_args):
                 in_string = True
                 cur = ''
             elif cur_char not in ' \t':
-                DEFAULT_LOG("Warning: Invalid unquoted character '%s' at index %d in coq-prog-args '%s'" % (cur_char, idx - 1, coq_prog_args))
+                DEFAULT_LOG("Warning: Invalid unquoted character '%s' at index %d in coq-prog-args '%s'" % (cur_char, idx - 1, coq_prog_args), level=LOG_ALWAYS)
                 return tuple(ret)
         else:
             if cur_char == '"':
@@ -289,7 +289,7 @@ def unescape_coq_prog_args(coq_prog_args):
                     cur += coq_prog_args[idx]
                     idx += 1
                 else:
-                    DEFAULT_LOG("Warning: Invalid backslash at end of coq-prog-args '%s'" % coq_prog_args)
+                    DEFAULT_LOG("Warning: Invalid backslash at end of coq-prog-args '%s'" % coq_prog_args, level=LOG_ALWAYS)
             else:
                 cur += cur_char
     return tuple(ret)
@@ -362,12 +362,12 @@ def get_header_dict(contents, old_header=None, original_line_count=0, **env):
 
 CONTENTS_UNCHANGED, CHANGE_SUCCESS, CHANGE_FAILURE = 'contents_unchanged', 'change_success', 'change_failure'
 def classify_contents_change(old_contents, new_contents, ignore_coq_output_cache=False, **kwargs):
-    # returns (RESULT_TYPE, PADDED_CONTENTS, OUTPUT_LIST, option BAD_INDEX, DESCRIPTION_OF_FAILURE_MODE, RUNTIME)
+    # returns (RESULT_TYPE, PADDED_CONTENTS, OUTPUT_LIST, option BAD_INDEX, DESCRIPTION_OF_FAILURE_MODE, RUNTIME, EXTRA_VERBOSE_DESCRIPTION_OF_FAILURE_MODE_TUPLE_LIST)
     kwargs['header_dict'] = kwargs.get('header_dict', get_header_dict(new_contents, original_line_count=len(old_contents.split('\n')), **env))
     # this is a function, so that once we update the header dict with the runtime, we get the right header
     def get_padded_contents(): return prepend_header(new_contents, **kwargs)
     if new_contents == old_contents:
-        return (CONTENTS_UNCHANGED, get_padded_contents(), tuple(), None, 'No change.  ', None)
+        return (CONTENTS_UNCHANGED, get_padded_contents(), tuple(), None, 'No change.  ', None, [])
 
     if ignore_coq_output_cache: diagnose_error.reset_coq_output_cache(kwargs['coqc'], kwargs['coqc_args'], new_contents, kwargs['timeout'], cwd=kwargs['base_dir'], is_coqtop=kwargs['coqc_is_coqtop'], verbose_base=2, **kwargs)
     output, cmds, retcode, runtime = diagnose_error.get_coq_output(kwargs['coqc'], kwargs['coqc_args'], new_contents, kwargs['timeout'], cwd=kwargs['base_dir'], is_coqtop=kwargs['coqc_is_coqtop'], verbose_base=2, **kwargs)
@@ -380,17 +380,16 @@ def classify_contents_change(old_contents, new_contents, ignore_coq_output_cache
                 # that in Coq's test-suite, the file should pass, and
                 # so this is a better indicator of how long it'll take
                 kwargs['header_dict']['recent_runtime'] = passing_runtime
-                return (CHANGE_SUCCESS, get_padded_contents(), (output, passing_output), None, 'Change successful.  ', passing_runtime)
+                return (CHANGE_SUCCESS, get_padded_contents(), (output, passing_output), None, 'Change successful.  ', passing_runtime, [])
             else:
-                return (CHANGE_FAILURE, get_padded_contents(), (output, passing_output), 1, 'The alternate coqc (%s) was supposed to pass, but instead emitted an error.  ' % kwargs['passing_coqc'], runtime)
+                return (CHANGE_FAILURE, get_padded_contents(), (output, passing_output), 1, 'The alternate coqc (%s) was supposed to pass, but instead emitted an error.  ' % kwargs['passing_coqc'], runtime, [])
         else:
             kwargs['header_dict']['recent_runtime'] = runtime
-            return (CHANGE_SUCCESS, get_padded_contents(), (output,), None, 'Change successful.  ', runtime)
+            return (CHANGE_SUCCESS, get_padded_contents(), (output,), None, 'Change successful.  ', runtime, [])
     else:
         extra_desc = ''
-        if kwargs['verbose'] >= 2:
-            extra_desc = 'The error was:\n%s\n' % output
-        return (CHANGE_FAILURE, get_padded_contents(), (output,), 0, extra_desc, runtime)
+        extra_desc_list = [(2, 'The error was:\n%s\n' % output)]
+        return (CHANGE_FAILURE, get_padded_contents(), (output,), 0, extra_desc, runtime, extra_desc_list)
 
 def check_change_and_write_to_file(old_contents, new_contents, output_file_name,
                                    unchanged_message='No change.', success_message='Change successful.',
@@ -398,47 +397,47 @@ def check_change_and_write_to_file(old_contents, new_contents, output_file_name,
                                    timeout_retry_count=1, ignore_coq_output_cache=False,
                                    verbose_base=1, display_source_to_error=False,
                                    **kwargs):
-    if kwargs['verbose'] >= 2 + verbose_base:
-        kwargs['log']('Running coq on the file\n"""\n%s\n"""' % new_contents)
-    change_result, contents, outputs, output_i, error_desc, runtime = classify_contents_change(old_contents, new_contents, ignore_coq_output_cache=ignore_coq_output_cache, **kwargs)
+    kwargs['log']('Running coq on the file\n"""\n%s\n"""' % new_contents, level=2 + verbose_base)
+    change_result, contents, outputs, output_i, error_desc, runtime, error_desc_verbose_list = classify_contents_change(old_contents, new_contents, ignore_coq_output_cache=ignore_coq_output_cache, **kwargs)
     if change_result == CONTENTS_UNCHANGED:
-        if kwargs['verbose'] >= verbose_base: kwargs['log']('\n%s' % unchanged_message)
+        kwargs['log']('\n%s' % unchanged_message, level=verbose_base)
         return False
     elif change_result == CHANGE_SUCCESS:
-        if kwargs['verbose'] >= verbose_base: kwargs['log']('\n%s' % success_message)
+        kwargs['log']('\n%s' % success_message, level=verbose_base)
         write_to_file(output_file_name, contents)
         return True
     elif change_result == CHANGE_FAILURE:
-        if kwargs['verbose'] >= verbose_base:
-            kwargs['log']('\nNon-fatal error: Failed to %s and preserve the error.  %s' % (failure_description, error_desc))
-            if not kwargs['remove_temp_file']: kwargs['log']('Writing %s to %s.' % (changed_description.lower(), kwargs['temp_file_name']))
-            kwargs['log']('The new error was:')
-            kwargs['log'](outputs[output_i])
-            if kwargs['verbose'] >= verbose_base+2: kwargs['log']('All Outputs:\n%s' % '\n'.join(outputs))
-            if kwargs['remove_temp_file']: kwargs['log']('%s not saved.' % changed_description)
+        kwargs['log']('\nNon-fatal error: Failed to %s and preserve the error.  %s' % (failure_description, error_desc), level=verbose_base)
+        for lvl, msg in error_desc_verbose_list: kwargs['log'](msg, level=lvl)
+        if not kwargs['remove_temp_file']: kwargs['log']('Writing %s to %s.' % (changed_description.lower(), kwargs['temp_file_name']), level=verbose_base)
+        kwargs['log']('The new error was:', level=verbose_base)
+        kwargs['log'](outputs[output_i], level=verbose_base)
+        kwargs['log']('All Outputs:\n%s' % '\n'.join(outputs), level=verbose_base+2)
+        if kwargs['remove_temp_file']: kwargs['log']('%s not saved.' % changed_description, level=verbose_base)
         if not kwargs['remove_temp_file']:
             write_to_file(kwargs['temp_file_name'], contents)
         if timeout_retry_count > 1 and diagnose_error.is_timeout(outputs[output_i]):
-            if kwargs['verbose'] >= verbose_base: kwargs['log']('\nRetrying another %d time%s...' % (timeout_retry_count - 1, 's' if timeout_retry_count > 2 else ''))
+            kwargs['log']('\nRetrying another %d time%s...' % (timeout_retry_count - 1, 's' if timeout_retry_count > 2 else ''), level=verbose_base)
             return check_change_and_write_to_file(old_contents, new_contents, output_file_name,
                                                   unchanged_message=unchanged_message, success_message=success_message,
                                                   failure_description=failure_description, changed_description=changed_description,
                                                   timeout_retry_count=timeout_retry_count-1, ignore_coq_output_cache=True,
                                                   verbose_base=verbose_base,
                                                   **kwargs)
-        elif kwargs['verbose'] >= verbose_base and display_source_to_error and diagnose_error.has_error(outputs[output_i]):
+        elif display_source_to_error and diagnose_error.has_error(outputs[output_i]):
             new_line = diagnose_error.get_error_line_number(outputs[output_i])
             new_start, new_end = diagnose_error.get_error_byte_locations(outputs[output_i])
             new_contents_lines = new_contents.split('\n')
             new_contents_to_error, new_contents_rest = '\n'.join(new_contents_lines[:new_line-1]), '\n'.join(new_contents_lines[new_line-1:])
-            kwargs['log']('The file generating the error was:')
+            kwargs['log']('The file generating the error was:', level=verbose_base)
             kwargs['log']('%s\n%s\n' % (new_contents_to_error,
-                                        new_contents_rest.encode('utf-8')[:new_end].decode('utf-8')))
+                                        new_contents_rest.encode('utf-8')[:new_end].decode('utf-8')), level=verbose_base)
         return False
     else:
         kwargs['log']('ERROR: Unrecognized change result %s on\nclassify_contents_change(\n  %s\n ,%s\n)\n%s'
                       % (change_result, repr(old_contents), repr(new_contents),
-                         repr((change_result, contents, outputs, output_i, error_desc, runtime))))
+                         repr((change_result, contents, outputs, output_i, error_desc, runtime, error_desc_verbose_list))),
+                      level=LOG_ALWAYS)
     return None
 
 
@@ -453,7 +452,7 @@ def try_transform_each(definitions, output_file_name, transformer, skip_n=1, **k
     reverse-order.
 
     Returns updated definitions."""
-    if kwargs['verbose'] >= 3: kwargs['log']('try_transform_each')
+    kwargs['log']('try_transform_each', level=3)
     original_definitions = [dict(i) for i in definitions]
     # TODO(jgross): Use coqtop and [BackTo] to do incremental checking
     success = False
@@ -466,7 +465,7 @@ def try_transform_each(definitions, output_file_name, transformer, skip_n=1, **k
                (INSTANCE_REG.search(old_definition['statement']) or
                 CANONICAL_STRUCTURE_REG.search(old_definition['statement']) or
                 TC_HINT_REG.search(old_definition['statement'])):
-                if kwargs['verbose'] >= 3: kwargs['log']('Ignoring Instance/Canonical Structure/Hint: %s' % old_definition['statement'])
+                kwargs['log']('Ignoring Instance/Canonical Structure/Hint: %s' % old_definition['statement'], level=3)
                 i -= 1
                 continue
             new_definitions = []
@@ -477,11 +476,13 @@ def try_transform_each(definitions, output_file_name, transformer, skip_n=1, **k
         if len(new_definitions) != 1 or \
                 re.sub(r'\s+', ' ', old_definition['statement']).strip() != re.sub(r'\s+', ' ', new_definitions[0]['statement']).strip():
             if len(new_definitions) == 0:
-                if kwargs['verbose'] >= 2: kwargs['log']('Attempting to remove %s' % repr(old_definition['statement']))
+                kwargs['log']('Attempting to remove %s' % repr(old_definition['statement']),
+                              level=2)
                 try_definitions = definitions[:i] + definitions[i + 1:]
             else:
-                if kwargs['verbose'] >= 2: kwargs['log']('Attempting to transform %s\ninto\n%s' % (old_definition['statement'], ''.join(defn['statement'] for defn in new_definitions)))
-                if kwargs['verbose'] >= 2 and len(new_definitions) > 1: kwargs['log']('Splitting definition: %s' % repr(new_definitions))
+                kwargs['log']('Attempting to transform %s\ninto\n%s' % (old_definition['statement'], ''.join(defn['statement'] for defn in new_definitions)),
+                              level=2)
+                if len(new_definitions) > 1: kwargs['log']('Splitting definition: %s' % repr(new_definitions), level=2)
                 try_definitions = definitions[:i] + new_definitions + definitions[i + 1:]
 
             if check_change_and_write_to_file('', join_definitions(try_definitions), output_file_name, verbose_base=2, **kwargs):
@@ -490,18 +491,18 @@ def try_transform_each(definitions, output_file_name, transformer, skip_n=1, **k
                 # make a copy for saving
                 save_definitions = [dict(defn) for defn in try_definitions]
         else:
-            if kwargs['verbose'] >= 3: kwargs['log']('No change to %s' % old_definition['statement'])
+            kwargs['log']('No change to %s' % old_definition['statement'], level=3)
         i -= 1
     if success:
-        if kwargs['verbose'] >= 1: kwargs['log'](kwargs['noun_description'] + ' successful')
+        kwargs['log'](kwargs['noun_description'] + ' successful')
         if join_definitions(save_definitions) != join_definitions(definitions):
-            kwargs['log']('Probably fatal error: definitions != save_definitions')
+            kwargs['log']('Probably fatal error: definitions != save_definitions', level=LOG_ALWAYS)
         else:
             contents = prepend_header(join_definitions(definitions), **kwargs)
             write_to_file(output_file_name, contents)
         return definitions
     else:
-        if kwargs['verbose'] >= 1: kwargs['log'](kwargs['noun_description'] + ' unsuccessful.')
+        kwargs['log'](kwargs['noun_description'] + ' unsuccessful.')
         return original_definitions
 
 
@@ -515,28 +516,29 @@ def try_transform_reversed(definitions, output_file_name, transformer, skip_n=1,
     passed in is guaranteed to be reverse-order.
 
     Returns updated definitions."""
-    if kwargs['verbose'] >= 3: kwargs['log']('try_transform_reversed')
+    kwargs['log']('try_transform_reversed', level=3)
     definitions = list(definitions) # clone the list of definitions
     original_definitions = list(definitions)
-    if kwargs['verbose'] >= 3: kwargs['log'](len(definitions))
-    if kwargs['verbose'] >= 3: kwargs['log'](definitions)
+    kwargs['log'](len(definitions), level=3)
+    kwargs['log'](definitions, level=3)
     for i in reversed(list(range(len(definitions) - skip_n))):
         new_definition = transformer(definitions[i], definitions[i + 1:])
         if new_definition:
             if definitions[i] != new_definition:
-                if kwargs['verbose'] >= 2: kwargs['log']('Transforming %s into %s' % (definitions[i]['statement'], new_definition['statement']))
+                kwargs['log']('Transforming %s into %s' % (definitions[i]['statement'], new_definition['statement']),
+                              level=2)
             else:
-                if kwargs['verbose'] >= 3: kwargs['log']('No change to %s' % new_definition['statement'])
+                kwargs['log']('No change to %s' % new_definition['statement'], level=3)
             definitions[i] = new_definition
         else:
             if kwargs['save_typeclasses'] and \
                (INSTANCE_REG.search(definitions[i]['statement']) or
                 CANONICAL_STRUCTURE_REG.search(definitions[i]['statement']) or
                 TC_HINT_REG.search(definitions[i]['statement'])):
-                if kwargs['verbose'] >= 3: kwargs['log']('Ignoring Instance/Canonical Structure/Hint: %s' % definitions[i]['statement'])
+                kwargs['log']('Ignoring Instance/Canonical Structure/Hint: %s' % definitions[i]['statement'], level=3)
                 pass
             else:
-                if kwargs['verbose'] >= 2: kwargs['log']('Removing %s' % definitions[i]['statement'])
+                kwargs['log']('Removing %s' % definitions[i]['statement'], level=2)
                 definitions = definitions[:i] + definitions[i + 1:]
 
     if check_change_and_write_to_file('', join_definitions(definitions), output_file_name,
@@ -557,24 +559,25 @@ def try_transform_reversed_or_else_each(definitions, *args, **kwargs):
     if new_definitions == old_definitions:
         # we failed to do everything at once, try the simple thing and
         # try to admit each individually
-        if kwargs['verbose'] >= 1: kwargs['log']('Failed to do everything at once; trying one at a time.')
+        kwargs['log']('Failed to do everything at once; trying one at a time.')
         definitions = try_transform_each(definitions, *args, **kwargs)
     new_definitions = join_definitions(definitions)
     if new_definitions == old_definitions:
-        if kwargs['verbose'] >= 1: kwargs['log']('No successful changes.')
+        kwargs['log']('No successful changes.')
     else:
-        if kwargs['verbose'] >= 1: kwargs['log']('Success!')
+        kwargs['log']('Success!')
     return definitions
 
 def try_remove_if_not_matches_transformer(definition_found_in, **kwargs):
     def transformer(cur_definition, rest_definitions):
         if any(definition_found_in(cur_definition, future_definition)
                for future_definition in rest_definitions):
-            if kwargs['verbose'] >= 3: kwargs['log']('Definition found; found:\n%s\nin\n%s'
-                                 % (cur_definition,
-                                    [future_definition['statement']
+            kwargs['log']('Definition found; found:\n%s\nin\n%s'
+                          % (cur_definition,
+                             [future_definition['statement']
                                      for future_definition in rest_definitions
-                                     if definition_found_in(cur_definition, future_definition)][0]))
+                                     if definition_found_in(cur_definition, future_definition)][0]),
+                          level=3)
             return cur_definition
         else:
             return None
@@ -734,7 +737,7 @@ def try_admit_abstracts(definitions, output_file_name, **kwargs):
     def do_call(method, definitions, agressive):
         return method(definitions, output_file_name,
                       (lambda definition, rest_definitions:
-                           transform_abstract_to_admit(definition, rest_definitions, agressive=agressive, verbose=kwargs['verbose'], log=kwargs['log'])),
+                           transform_abstract_to_admit(definition, rest_definitions, agressive=agressive, log=kwargs['log'])),
                       noun_description='Admitting [abstract ...]',
                       verb_description='[abstract ...] admits',
                       **kwargs)
@@ -746,32 +749,35 @@ def try_admit_abstracts(definitions, output_file_name, **kwargs):
     definitions = do_call(try_transform_reversed, definitions, True)
     new_definitions = join_definitions(definitions)
     if new_definitions != old_definitions:
-        if kwargs['verbose'] >= 3: kwargs['log']('Success with [abstract ...] admits on try_transform_reversed, agressive: True, definitions:\n%s'
-                             % new_definitions)
+        kwargs['log']('Success with [abstract ...] admits on try_transform_reversed, agressive: True, definitions:\n%s'
+                      % new_definitions,
+                      level=3)
         return definitions
 
     # try the other options, each less agressive than the last
     definitions = do_call(try_transform_reversed, definitions, False)
     new_definitions = join_definitions(definitions)
     if new_definitions != old_definitions:
-        if kwargs['verbose'] >= 3: kwargs['log']('Success with [abstract ...] admits on try_transform_reversed, agressive: False, definitions:\n%s'
-                             % new_definitions)
+        kwargs['log']('Success with [abstract ...] admits on try_transform_reversed, agressive: False, definitions:\n%s'
+                      % new_definitions,
+                      level=3)
         return definitions
 
     definitions = do_call(try_transform_each, definitions, True)
     new_definitions = join_definitions(definitions)
     if new_definitions != old_definitions:
-        if kwargs['verbose'] >= 3: kwargs['log']('Success with [abstract ...] admits on try_transform_each, agressive: True, definitions:\n%s'
-                             % new_definitions)
+        kwargs['log']('Success with [abstract ...] admits on try_transform_each, agressive: True, definitions:\n%s'
+                      % new_definitions,
+                      level=3)
         return definitions
 
     definitions = do_call(try_transform_each, definitions, False)
     new_definitions = join_definitions(definitions)
     if new_definitions != old_definitions:
-        if kwargs['verbose'] >= 3: kwargs['log']('Success with [abstract ...] admits on try_transform_each, agressive: False, definitions:\n%s'
-                             % new_definitions)
+        kwargs['log']('Success with [abstract ...] admits on try_transform_each, agressive: False, definitions:\n%s'
+                      % new_definitions, level=3)
     else:
-        if kwargs['verbose'] >= 3: kwargs['log']('Failure with [abstract ...] admits.')
+        kwargs['log']('Failure with [abstract ...] admits.', level=3)
     return definitions
 
 
@@ -977,7 +983,7 @@ def try_strip_extra_lines(output_file_name, line_num, **kwargs):
                                       failure_description='trim file',
                                       changed_descruption='Trimmed file',
                                       **kwargs):
-        if kwargs['verbose'] >= 3: kwargs['log']('Trimmed file:\n%s' % read_from_file(output_file_name))
+        kwargs['log']('Trimmed file:\n%s' % read_from_file(output_file_name), level=3)
 
 
 
@@ -1042,26 +1048,25 @@ def minimize_file(output_file_name, die=default_on_fatal, **env):
         return die('Fatal error: Sanity check failed.')
 
     if env['max_consecutive_newlines'] >= 0 or env['strip_trailing_space']:
-        if env['verbose'] >= 1: env['log']('\nNow, I will attempt to strip repeated newlines and trailing spaces from this file...')
+        env['log']('\nNow, I will attempt to strip repeated newlines and trailing spaces from this file...')
         try_strip_newlines(output_file_name, **env)
 
     contents = read_from_file(output_file_name)
     original_line_count = len(contents.split('\n'))
     env['header_dict']['original_line_count'] = original_line_count
 
-    if env['verbose'] >= 1: env['log']('\nNow, I will attempt to strip the comments from this file...')
+    env['log']('\nNow, I will attempt to strip the comments from this file...')
     try_strip_comments(output_file_name, **env)
 
 
 
     contents = read_from_file(output_file_name)
-    if env['verbose'] >= 1:
-        env['log']('\nIn order to efficiently manipulate the file, I have to break it into statements.  I will attempt to do this by matching on periods.')
-        strings = re.findall(r'"[^"\n\r]+"', contents)
-        bad_strings = [i for i in strings if re.search(r'(?<=[^\.]\.\.\.)\s|(?<=[^\.]\.)\s', i)]
-        if bad_strings:
-            env['log']('If you have periods in strings, and these periods are essential to generating the error, then this process will fail.  Consider replacing the string with some hack to get around having a period and then a space, like ["a. b"%string] with [("a." ++ " b")%string].')
-            env['log']('You have the following strings with periods in them:\n%s' % '\n'.join(bad_strings))
+    env['log']('\nIn order to efficiently manipulate the file, I have to break it into statements.  I will attempt to do this by matching on periods.')
+    strings = re.findall(r'"[^"\n\r]+"', contents)
+    bad_strings = [i for i in strings if re.search(r'(?<=[^\.]\.\.\.)\s|(?<=[^\.]\.)\s', i)]
+    if bad_strings:
+        env['log']('If you have periods in strings, and these periods are essential to generating the error, then this process will fail.  Consider replacing the string with some hack to get around having a period and then a space, like ["a. b"%string] with [("a." ++ " b")%string].')
+        env['log']('You have the following strings with periods in them:\n%s' % '\n'.join(bad_strings))
     statements = split_coq_file_contents(contents)
     if not check_change_and_write_to_file('', '\n'.join(statements), output_file_name,
                                           unchanged_message='Invalid empty file!',
@@ -1070,20 +1075,20 @@ def minimize_file(output_file_name, die=default_on_fatal, **env):
                                           changed_description='Split',
                                           timeout_retry_count=SENSITIVE_TIMEOUT_RETRY_COUNT,
                                           **env):
-        if env['verbose'] >= 1: env['log']('I will not be able to proceed.')
-        if env['verbose'] >= 2: env['log']('re.search(' + repr(env['error_reg_string']) + ', <output above>)')
+        env['log']('I will not be able to proceed.')
+        env['log']('re.search(' + repr(env['error_reg_string']) + ', <output above>)', level=2)
         return die(None)
 
-    if env['verbose'] >= 1: env['log']('\nI will now attempt to remove any lines after the line which generates the error.')
+    env['log']('\nI will now attempt to remove any lines after the line which generates the error.')
     output, cmds, retcode, runtime = diagnose_error.get_coq_output(env['coqc'], env['coqc_args'], '\n'.join(statements), env['timeout'], is_coqtop=env['coqc_is_coqtop'], verbose_base=2, **env)
     line_num = diagnose_error.get_error_line_number(output, env['error_reg_string'])
     try_strip_extra_lines(output_file_name, line_num, **env)
 
 
-    if env['verbose'] >= 1: env['log']('\nIn order to efficiently manipulate the file, I have to break it into definitions.  I will now attempt to do this.')
+    env['log']('\nIn order to efficiently manipulate the file, I have to break it into definitions.  I will now attempt to do this.')
     contents = read_from_file(output_file_name)
     statements = split_coq_file_contents(contents)
-    if env['verbose'] >= 3: env['log']('I am using the following file: %s' % '\n'.join(statements))
+    env['log']('I am using the following file: %s' % '\n'.join(statements), level=3)
     definitions = split_statements_to_definitions(statements, **env)
     if not check_change_and_write_to_file('', join_definitions(definitions), output_file_name,
                                           unchanged_message='Invalid empty file!',
@@ -1092,8 +1097,8 @@ def minimize_file(output_file_name, die=default_on_fatal, **env):
                                           changed_description='Split',
                                           timeout_retry_count=SENSITIVE_TIMEOUT_RETRY_COUNT,
                                           **env):
-        if env['verbose'] >= 1: env['log']('I will not be able to proceed.')
-        if env['verbose'] >= 2: env['log']('re.search(' + repr(env['error_reg_string']) + ', <output above>)')
+        env['log']('I will not be able to proceed.')
+        env['log']('re.search(' + repr(env['error_reg_string']) + ', <output above>)', level=2)
         return die(None)
 
     recursive_tasks = (('remove goals ending in [Abort.]', try_remove_aborted),
@@ -1139,19 +1144,19 @@ def minimize_file(output_file_name, die=default_on_fatal, **env):
     old_definitions = ''
     while old_definitions != join_definitions(definitions):
         old_definitions = join_definitions(definitions)
-        if env['verbose'] >= 2: env['log']('Definitions:')
-        if env['verbose'] >= 2: env['log'](definitions)
+        env['log']('Definitions:', level=2)
+        env['log'](definitions, level=2)
 
         for description, task in tasks:
-            if env['verbose'] >= 1: env['log']('\nI will now attempt to %s' % description)
+            env['log']('\nI will now attempt to %s' % description)
             definitions = task(definitions, output_file_name, **env)
 
 
-    if env['verbose'] >= 1: env['log']('\nI will now attempt to remove empty sections')
+    env['log']('\nI will now attempt to remove empty sections')
     try_strip_empty_sections(output_file_name, **env)
 
     if env['max_consecutive_newlines'] >= 0 or env['strip_trailing_space']:
-        if env['verbose'] >= 1: env['log']('\nNow, I will attempt to strip repeated newlines and trailing spaces from this file...')
+        env['log']('\nNow, I will attempt to strip repeated newlines and trailing spaces from this file...')
         try_strip_newlines(output_file_name, **env)
 
     return True
@@ -1177,7 +1182,6 @@ if __name__ == '__main__':
     bug_file_name = args.bug_file.name
     output_file_name = args.output_file
     env = {
-        'verbose': args.verbose,
         'fast_merge_imports': args.fast_merge_imports,
         'log': args.log,
         'coqc': prepend_coqbin(args.coqc),
@@ -1197,18 +1201,18 @@ if __name__ == '__main__':
         'aggressive': args.aggressive,
         'admit_transparent': args.admit_transparent and args.admit_any,
         'coqc_args': tuple(i.strip()
-                           for i in (list(process_maybe_list(args.nonpassing_coqc_args, log=args.log, verbose=args.verbose))
-                                     + list(process_maybe_list(args.nonpassing_coq_args, log=args.log, verbose=args.verbose))
-                                     + list(process_maybe_list(args.coq_args, log=args.log, verbose=args.verbose)))),
+                           for i in (list(process_maybe_list(args.nonpassing_coqc_args, log=args.log))
+                                     + list(process_maybe_list(args.nonpassing_coq_args, log=args.log))
+                                     + list(process_maybe_list(args.coq_args, log=args.log)))),
         'coqtop_args': tuple(i.strip()
-                             for i in (list(process_maybe_list(args.coqtop_args, log=args.log, verbose=args.verbose))
-                                       + list(process_maybe_list(args.nonpassing_coq_args, log=args.log, verbose=args.verbose))
-                                       + list(process_maybe_list(args.coq_args, log=args.log, verbose=args.verbose)))),
+                             for i in (list(process_maybe_list(args.coqtop_args, log=args.log))
+                                       + list(process_maybe_list(args.nonpassing_coq_args, log=args.log))
+                                       + list(process_maybe_list(args.coq_args, log=args.log)))),
         'coq_makefile': prepend_coqbin(args.coq_makefile),
         'passing_coqc_args': tuple(i.strip()
-                                   for i in (list(process_maybe_list(args.passing_coqc_args, log=args.log, verbose=args.verbose))
-                                             + list(process_maybe_list(args.passing_coq_args, log=args.log, verbose=args.verbose))
-                                             + list(process_maybe_list(args.coq_args, log=args.log, verbose=args.verbose)))),
+                                   for i in (list(process_maybe_list(args.passing_coqc_args, log=args.log))
+                                             + list(process_maybe_list(args.passing_coq_args, log=args.log))
+                                             + list(process_maybe_list(args.coq_args, log=args.log)))),
         'passing_coqc' : (prepend_coqbin(args.passing_coqc)
                           if args.passing_coqc != ''
                           else (prepend_coqbin(args.coqc)
@@ -1231,18 +1235,18 @@ if __name__ == '__main__':
         }
 
     if bug_file_name[-2:] != '.v':
-        env['log']('\nError: BUGGY_FILE must end in .v (value: %s)' % bug_file_name, force_stdout=True)
+        env['log']('\nError: BUGGY_FILE must end in .v (value: %s)' % bug_file_name, force_stdout=True, level=LOG_ALWAYS)
         sys.exit(1)
     if output_file_name[-2:] != '.v':
-        env['log']('\nError: OUT_FILE must end in .v (value: %s)' % output_file_name, force_stdout=True)
+        env['log']('\nError: OUT_FILE must end in .v (value: %s)' % output_file_name, force_stdout=True, level=LOG_ALWAYS)
         sys.exit(1)
     if os.path.exists(output_file_name):
-        env['log']('\nWarning: OUT_FILE (%s) already exists.  Would you like to overwrite?\n' % output_file_name, force_stdout=True)
+        env['log']('\nWarning: OUT_FILE (%s) already exists.  Would you like to overwrite?\n' % output_file_name, force_stdout=True, level=LOG_ALWAYS)
         if not yes_no_prompt(yes=env['yes']):
             sys.exit(1)
     for k, arg in (('base_dir', '--base-dir'), ('passing_base_dir', '--passing-base-dir')):
         if env[k] is not None and not os.path.isdir(env[k]):
-            env['log']('\nError: Argument to %s (%s) must exist and be a directory.' % (arg, env[k]), force_stdout=True)
+            env['log']('\nError: Argument to %s (%s) must exist and be a directory.' % (arg, env[k]), force_stdout=True, level=LOG_ALWAYS)
             sys.exit(1)
 
     env['remove_temp_file'] = False
@@ -1270,11 +1274,10 @@ if __name__ == '__main__':
             if env[passing_prefix + 'coqc']:
                 update_env_with_coqpath_folders(passing_prefix, env, os.path.join(get_coqc_coqlib(env[passing_prefix + 'coqc'], **env), 'user-contrib'))
 
-    if env['verbose'] >= 2:
-        env['log']('{')
-        for k, v in sorted(list(env.items())):
-            env['log']('  %s: %s' % (repr(k), repr(v)))
-        env['log']('}')
+    env['log']('{', level=2)
+    for k, v in sorted(list(env.items())):
+        env['log']('  %s: %s' % (repr(k), repr(v)), level=2)
+    env['log']('}', level=2)
 
     for passing_prefix in ('', 'passing_'):
         if env[passing_prefix + 'coqc']:
@@ -1285,10 +1288,10 @@ if __name__ == '__main__':
     try:
 
         if env['temp_file_name'][-2:] != '.v':
-            env['log']('\nError: TEMP_FILE must end in .v (value: %s)' % env['temp_file_name'], force_stdout=True)
+            env['log']('\nError: TEMP_FILE must end in .v (value: %s)' % env['temp_file_name'], force_stdout=True, level=LOG_ALWAYS)
             sys.exit(1)
 
-        if env['verbose'] >= 1: env['log']('\nCoq version: %s\n' % coqc_version)
+        env['log']('\nCoq version: %s\n' % coqc_version)
 
         extra_args = get_coq_prog_args(get_file(bug_file_name, **env)) if args.use_coq_prog_args else []
         for args_name, coq_prog, passing_prefix in (('coqc_args', env['coqc'], ''), ('coqtop_args', env['coqtop'], ''), ('passing_coqc_args', env['passing_coqc'] if env['passing_coqc'] else env['coqc'], 'passing_')):
@@ -1307,7 +1310,7 @@ if __name__ == '__main__':
                 if arg[0] == '-I': env.get(passing_prefix + 'ocaml_dirnames', []).append(arg[1])
 
         if env['minimize_before_inlining']:
-            if env['verbose'] >= 1: env['log']('\nFirst, I will attempt to factor out all of the [Require]s %s, and store the result in %s...' % (bug_file_name, output_file_name))
+            env['log']('\nFirst, I will attempt to factor out all of the [Require]s %s, and store the result in %s...' % (bug_file_name, output_file_name))
             inlined_contents = normalize_requires(bug_file_name, **env)
             args.bug_file.close()
             inlined_contents = maybe_add_coqlib_import(inlined_contents, **env)
@@ -1315,19 +1318,19 @@ if __name__ == '__main__':
             write_to_file(output_file_name, inlined_contents)
         else:
             if env['inline_coqlib']:
-                env['log']('\nError: --inline-coqlib is incompatible with --no-minimize-before-inlining;\nthe Coq standard library is not suited for inlining all-at-once.', force_stdout=True)
+                env['log']('\nError: --inline-coqlib is incompatible with --no-minimize-before-inlining;\nthe Coq standard library is not suited for inlining all-at-once.', force_stdout=True, level=LOG_ALWAYS)
                 sys.exit(1)
-            if env['verbose'] >= 1: env['log']('\nFirst, I will attempt to inline all of the inputs in %s, and store the result in %s...' % (bug_file_name, output_file_name))
+            env['log']('\nFirst, I will attempt to inline all of the inputs in %s, and store the result in %s...' % (bug_file_name, output_file_name))
             inlined_contents = include_imports(bug_file_name, **env)
             args.bug_file.close()
             if inlined_contents:
                 inlined_contents = add_admit_tactic(inlined_contents, **env)
-                if env['verbose'] >= 1: env['log']('Stripping trailing ends')
+                env['log']('Stripping trailing ends')
                 while re.search(r'End [^ \.]*\.\s*$', inlined_contents):
                     inlined_contents = re.sub(r'End [^ \.]*\.\s*$', '', inlined_contents)
                 write_to_file(output_file_name, inlined_contents)
             else:
-                if env['verbose'] >= 1: env['log']('Failed to inline inputs.')
+                env['log']('Failed to inline inputs.')
                 sys.exit(1)
 
         if env['inline_coqlib']:
@@ -1335,11 +1338,11 @@ if __name__ == '__main__':
                 env[key] = tuple(list(env[key]) + ['-nois', '-coqlib', env['inline_coqlib']])
             env['libnames'] = tuple(list(env['libnames']) + [(os.path.join(env['inline_coqlib'], 'theories'), 'Coq')])
 
-        if env['verbose'] >= 1: env['log']('\nNow, I will attempt to coq the file, and find the error...')
+        env['log']('\nNow, I will attempt to coq the file, and find the error...')
         env['error_reg_string'] = get_error_reg_string(output_file_name, **env)
 
         if args.error_log:
-            if env['verbose'] >= 1: env['log']('\nNow, I will attempt to find the error message in the log...')
+            env['log']('\nNow, I will attempt to find the error message in the log...')
             error_log = args.error_log.read()
             args.error_log.close()
             if not diagnose_error.has_error(error_log, env['error_reg_string']):
@@ -1371,8 +1374,8 @@ if __name__ == '__main__':
                         libname_blacklist.append(req_module)
                     rep = '\nRequire %s.\n' % req_module
                     if rep not in '\n' + cur_output:
-                        if env['verbose'] >= 1: env['log']('\nWarning: I cannot find Require %s.' % req_module)
-                        if env['verbose'] >= 3: env['log']('in contents:\n' + cur_output)
+                        env['log']('\nWarning: I cannot find Require %s.' % req_module)
+                        env['log']('in contents:\n' + cur_output, level=3)
                         continue
                     try:
                         # we prefer wrapping modules via Include,
@@ -1388,7 +1391,7 @@ if __name__ == '__main__':
                             (' without Include, absolutizing mod references', get_test_output(absolutize_mods=True, first_wrap_then_include=False))
                         ]
                     except IOError as e:
-                        if env['verbose'] >= 1: env['log']('\nWarning: Cannot inline %s (%s)\nRecursively Searched: %s\nNonrecursively Searched: %s' % (req_module, str(e), str(tuple(env['libnames'])), str(tuple(env['non_recursive_libnames']))))
+                        env['log']('\nWarning: Cannot inline %s (%s)\nRecursively Searched: %s\nNonrecursively Searched: %s' % (req_module, str(e), str(tuple(env['libnames'])), str(tuple(env['non_recursive_libnames']))))
                         continue
 
                     diagnose_error.reset_timeout()
@@ -1424,7 +1427,7 @@ if __name__ == '__main__':
                                 **env)
 
                             extra_blacklist = [r for r in get_recursive_require_names(req_module, **env) if r not in libname_blacklist]
-                            if extra_blacklist and env['verbose'] >= 1:
+                            if extra_blacklist:
                                 env['log']('\nWarning: Preemptively skipping recursive dependency module%s: %s\n'
                                            % (('' if len(extra_blacklist) == 1 else 's'), ', '.join(extra_blacklist)))
                             libname_blacklist.extend(extra_blacklist)
@@ -1442,14 +1445,14 @@ if __name__ == '__main__':
             minimize_file(output_file_name, **env)
 
     except EOFError:
-        env['log'](traceback.format_exc())
+        env['log'](traceback.format_exc(), level=LOG_ALWAYS)
         raise
     except Exception:
         if hasattr(traceback, 'TracebackException'):
             etype, value, tb = sys.exc_info()
-            env['log'](''.join(traceback.TracebackException(type(value), value, tb, capture_locals=True).format()))
+            env['log'](''.join(traceback.TracebackException(type(value), value, tb, capture_locals=True).format()), level=LOG_ALWAYS)
         else:
-            env['log'](traceback.format_exc())
+            env['log'](traceback.format_exc(), level=LOG_ALWAYS)
         raise
     finally:
         if env['remove_temp_file']:

--- a/inline-imports.py
+++ b/inline-imports.py
@@ -60,7 +60,6 @@ if __name__ == '__main__':
     args = process_logging_arguments(parser.parse_args())
 
     env = {
-        'verbose': args.verbose,
         'log': args.log,
         'coqc': (args.coqc if args.coqbin == '' else os.path.join(args.coqbin, args.coqc)),
         'absolutize': args.absolutize,

--- a/split_definitions_old.py
+++ b/split_definitions_old.py
@@ -5,8 +5,9 @@ __all__ = ["join_definitions", "split_statements_to_definitions"]
 
 DEFAULT_VERBOSITY=1
 
-def DEFAULT_LOG(text):
-    print(text)
+def DEFAULT_LOG(text, level=DEFAULT_VERBOSITY):
+    if level <= DEFAULT_VERBOSITY:
+        print(text)
 
 def get_all_nowait_iter(q):
     try:
@@ -18,10 +19,9 @@ def get_all_nowait_iter(q):
 def get_all_nowait(q):
     return ''.join(get_all_nowait_iter(q))
 
-def get_all_semiwait_iter(q, verbose=DEFAULT_VERBOSITY, log=DEFAULT_LOG):
+def get_all_semiwait_iter(q, log=DEFAULT_LOG):
     def log_and_return(val):
-        if verbose >= 5:
-            log(val)
+        log(val, level=5)
         return val
     try:
         # this is blocking; TODO(jgross): Figure out how to get coqtop
@@ -32,8 +32,8 @@ def get_all_semiwait_iter(q, verbose=DEFAULT_VERBOSITY, log=DEFAULT_LOG):
     except Empty:
         pass
 
-def get_all_semiwait(q, verbose=DEFAULT_VERBOSITY, log=DEFAULT_LOG):
-    return ''.join(get_all_semiwait_iter(q, verbose=verbose, log=log))
+def get_all_semiwait(q, log=DEFAULT_LOG):
+    return ''.join(get_all_semiwait_iter(q, log=log))
 
 def get_definitions_diff(previous_definition_string, new_definition_string):
     """Returns a triple of lists (definitions_removed,
@@ -45,7 +45,7 @@ def get_definitions_diff(previous_definition_string, new_definition_string):
             tuple(i for i in new_definitions if i not in old_definitions))
 
 
-#def split_coq_code_to_definitions(code, verbose=1, log=DEFAULT_LOG, coqtop='coqtop'):
+#def split_coq_code_to_definitions(code, log=DEFAULT_LOG, coqtop='coqtop'):
 #    """Splits coq code into chunks which make up
 #    independent definitions/hints/etc, of the form
 #
@@ -60,7 +60,7 @@ def get_definitions_diff(previous_definition_string, new_definition_string):
 #    time.sleep(1)
 
 
-def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=DEFAULT_LOG, coqtop='coqtop', coqtop_args=tuple()):
+def split_statements_to_definitions(statements, log=DEFAULT_LOG, coqtop='coqtop', coqtop_args=tuple()):
     """Splits a list of statements into chunks which make up
     independent definitions/hints/etc."""
     p = Popen_async([coqtop, '-q', '-emacs'] + list(coqtop_args), stdout=PIPE, stderr=STDOUT, stdin=PIPE)
@@ -71,7 +71,7 @@ def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=D
     # goal_reg = re.compile(r'^\s*=+\s*$', re.MULTILINE)
     # goals and definitions are on stdout, prompts are on stderr
     # clear stdout
-    get_all_semiwait(p.stdout, verbose=verbose, log=log)
+    get_all_semiwait(p.stdout, log=log)
     # clear stderr
     # get_all_nowait(p.stderr)
 
@@ -82,11 +82,10 @@ def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=D
     for statement in statements:
         if not statement.strip():
             continue
-        if verbose >= 4:
-            log('Write: %s\n\nWait to read...' % statement)
+        log('Write: %s\n\nWait to read...' % statement, level=4)
         p.stdin.write(statement + '\n\n')
         p.stdin.flush()
-        stdout = get_all_semiwait(p.stdout, verbose=verbose, log=log)
+        stdout = get_all_semiwait(p.stdout, log=log)
         stderr = stdout # ''.join(get_all_semiwait(p.stderr))
 
         terms_defined = defined_reg.findall(prompt_reg.sub('', stdout))
@@ -95,16 +94,14 @@ def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=D
 
         if not prompt_match or len(prompt_match.groups()) != 5:
             if not prompt_match:
-                if verbose:
-                    log('Likely fatal warning: I did not recognize the output from coqtop:')
-                    log('stdout: %s\nstderr: %s' % (repr(stdout), repr(stderr)))
-                    log("I will append the current statement (%s) to the list of definitions as-is, but I don't expect this to work." % statement)
+                log('Likely fatal warning: I did not recognize the output from coqtop:')
+                log('stdout: %s\nstderr: %s' % (repr(stdout), repr(stderr)))
+                log("I will append the current statement (%s) to the list of definitions as-is, but I don't expect this to work." % statement)
             else:
-                if verbose:
-                    log("Crazy things are happening; the number of groups isn't what it should be (should be 5 groups):")
-                    log("prompt_match.groups(): %s\nstdout: %s\nstderr: %s\nstatement: %s\n" % (repr(prompt_match.groups()), repr(stdout), repr(stderr), repr(statement)))
+                log("Crazy things are happening; the number of groups isn't what it should be (should be 5 groups):")
+                log("prompt_match.groups(): %s\nstdout: %s\nstderr: %s\nstatement: %s\n" % (repr(prompt_match.groups()), repr(stdout), repr(stderr), repr(statement)))
 
-            if verbose >= 2: log((statement, terms_defined, cur_definition_names, cur_definition.get(cur_definition_names, [])))
+            log((statement, terms_defined, cur_definition_names, cur_definition.get(cur_definition_names, [])), level=2)
             if cur_definition_names.strip('|'):
                 cur_definition[cur_definition_names]['statements'].append(statement)
                 cur_definition[cur_definition_names]['terms_defined'] += terms_defined
@@ -122,7 +119,7 @@ def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=D
                 cur_definition[cur_definition_names] = {'statements':[], 'terms_defined':[]}
 
 
-            if verbose >= 2: log((statement, terms_defined, last_definitions, cur_definition_names, cur_definition.get(last_definitions, []), cur_definition.get(cur_definition_names, [])))
+            log((statement, terms_defined, last_definitions, cur_definition_names, cur_definition.get(last_definitions, []), cur_definition.get(cur_definition_names, [])), level=2)
 
 
             # first, we handle the case where we have just finished
@@ -186,7 +183,7 @@ def split_statements_to_definitions(statements, verbose=DEFAULT_VERBOSITY, log=D
                                 'terms_defined':tuple()})
         last_definitions = cur_definition_names
 
-    if verbose >= 2: log((last_definitions, cur_definition_names))
+    log((last_definitions, cur_definition_names), level=2)
     if last_definitions.strip('||'):
         rtn.append({'statements':tuple(cur_definition[cur_definition_names]['statements']),
                     'statement':'\n'.join(cur_definition[cur_definition_names]['statements']),

--- a/split_file.py
+++ b/split_file.py
@@ -1,5 +1,5 @@
 from strip_comments import strip_comments
-from custom_arguments import DEFAULT_LOG, DEFAULT_VERBOSITY
+from custom_arguments import DEFAULT_LOG
 from coq_version import get_coq_accepts_time
 import subprocess
 import re
@@ -11,7 +11,6 @@ __all__ = ["split_coq_file_contents", "split_coq_file_contents_with_comments", "
 
 def fill_kwargs(kwargs):
     ret = {
-        'verbose'               : DEFAULT_VERBOSITY,
         'log'                   : DEFAULT_LOG,
         'coqc'                  : 'coqc',
         'coqc_args'             : tuple(),
@@ -178,11 +177,10 @@ def postprocess_split_proof_term_iter(statements, on_first_example=None):
             yield statement
 def postprocess_split_proof_term(statements, do_warn=True, **kwargs):
     def do_warn_method(statement_num, statement, proof_term):
-        if kwargs['verbose'] > 0:
-            kwargs['log']("""Warning: Your version of Coq suffers from bug #5349 (https://coq.inria.fr/bugs/show_bug.cgi?id=5349)
+        kwargs['log']("""Warning: Your version of Coq suffers from bug #5349 (https://coq.inria.fr/bugs/show_bug.cgi?id=5349)
 and does not support [Proof (term).] with -time.  Falling back to
 replacing [Proof (term).] with [Proof. exact (term). Qed.], which may fail.""")
-    if do_warn and 'verbose' in kwargs.keys() and 'log' in kwargs.keys():
+    if do_warn and 'log' in kwargs.keys():
         do_warn = do_warn_method
     else:
         do_warn = None


### PR DESCRIPTION
Fixes #76

We invert the control-flow of verbosity logic and add
`--verbose-log-file` (e.g., `--verbose-log-file 10,very-verbose.log
0,quiet.log 2,-`) to allow logging of different verbosities to different
files.  This will allow more verbose logging on CI minimization without
polluting the displayed log.