### PR TITLE
Emit a warning & `--no-deps` suggestion

### DIFF
--- a/coq_tools/import_util.py
+++ b/coq_tools/import_util.py
@@ -405,9 +405,9 @@ def run_coq_makefile_and_make(v_files, targets, **kwargs):
     make_cmds = ['make', '-k', '-f', mkfile] + keep_error_fragment + targets
     kwargs['log'](' '.join(make_cmds))
     try:
-        p_make = subprocess.Popen(make_cmds, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        p_make = subprocess.Popen(make_cmds, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         p_make_stdout, p_make_stderr = p_make.communicate()
-        return p_make_stdout
+        return p_make_stdout.decode('utf-8')
     finally:
         for filename in (mkfile, mkfile + '.conf', mkfile + '.d', '.%s.d' % mkfile, '.coqdeps.d'):
             if os.path.exists(filename):


### PR DESCRIPTION
As per
https://github.com/JasonGross/coq-tools/issues/176#issuecomment-1777726114, https://github.com/JasonGross/coq-tools/issues/176#issuecomment-1777764511, and
https://github.com/JasonGross/coq-tools/issues/176#issuecomment-1781782890, we suggest passing `--no-deps` when `make` complains `Argument list too long` and `No rule to make target '.*.glob'`.

Hopefully this will make the lives of anyone else in the position @Janno was in marginally easier in the future