### PR TITLE
Be more robust to utf-8 decoding errors

### DIFF
--- a/coq_tools/find_bug.py
+++ b/coq_tools/find_bug.py
@@ -1018,8 +1018,12 @@ def try_split_requires(output_file_name, **kwargs):
         kwargs['log']('\nNon-fatal error: Failed to get references for %s' % output_file_name, level=LOG_ALWAYS)
         return False
 
-    annotated_contents = split_requires_of_statements(annotated_contents, **kwargs)
-    new_contents = ''.join(v[0].decode('utf-8') for v in annotated_contents)
+    try:
+        annotated_contents = split_requires_of_statements(annotated_contents, **kwargs)
+        new_contents = ''.join(v[0].decode('utf-8') for v in annotated_contents)
+    except UnicodeDecodeError as e:
+        kwargs['log']('\nNon-fatal error: Invalid non-UTF-8 (maybe an outdated .glob file for %s?): %s' % (output_file_name, str(e)), level=LOG_ALWAYS)
+        return False
 
     return check_change_and_write_to_file(old_contents, new_contents, output_file_name,
                                           unchanged_message='No Requires to split.',


### PR DESCRIPTION
Fix #176

When .glob files are outdated, we will just fail to split requires.  We could try to be more fine-grained and gracefully skip over statements where there's a decoding error, but given how heavily we rely on .glob files for inlining, I don't think there's much harm in failing to split `Require`s all-together when the .glob file is outdated.