### PR TITLE
Set up infrastructure for `--no-deps` warning

### DIFF
--- a/coq_tools/absolutize_imports.py
+++ b/coq_tools/absolutize_imports.py
@@ -2,7 +2,7 @@
 import shutil, os, os.path, sys
 from .argparse_compat import argparse
 from .import_util import get_file, sort_files_by_dependency, IMPORT_ABSOLUTIZE_TUPLE, ALL_ABSOLUTIZE_TUPLE
-from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments
+from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, get_parser_name_mapping
 from .file_util import write_to_file
 
 __all__ = ['main']
@@ -52,6 +52,7 @@ def main():
         'absolutize': args.absolutize,
         'coq_makefile': prepend_coqbin(args.coq_makefile),
         'input_files': tuple(f.name for f in args.input_files),
+        'cli_mapping': get_parser_name_mapping(parser),
         }
     update_env_with_libnames(env, args)
 

--- a/coq_tools/custom_arguments.py
+++ b/coq_tools/custom_arguments.py
@@ -3,7 +3,7 @@ import sys, os
 from .argparse_compat import argparse
 from .util import PY3
 
-__all__ = ["add_libname_arguments", "add_passing_libname_arguments", "ArgumentParser", "update_env_with_libnames", "add_logging_arguments", "process_logging_arguments", "update_env_with_coqpath_folders", "DEFAULT_LOG", "DEFAULT_VERBOSITY", "LOG_ALWAYS"]
+__all__ = ["add_libname_arguments", "add_passing_libname_arguments", "ArgumentParser", "update_env_with_libnames", "add_logging_arguments", "process_logging_arguments", "update_env_with_coqpath_folders", "DEFAULT_LOG", "DEFAULT_VERBOSITY", "LOG_ALWAYS", "get_parser_name_mapping"]
 
 # grumble, grumble, we want to support multiple -R arguments like coqc
 class CoqLibnameAction(argparse.Action):
@@ -260,3 +260,15 @@ class ArgumentParser(argparse.ArgumentParser):
             exc.reraise = reraise
             raise exc
         reraise()
+
+# returns a mapping from constant names to values to lists of command-line flags
+def get_parser_name_mapping(parser):
+    mapping = {}
+    for action in parser._actions:
+        if hasattr(action, 'const') and action.const is not None and len(action.option_strings) > 0:
+            dest = action.dest
+            const = action.const
+            if dest not in mapping: mapping[dest] = {}
+            if const not in mapping[dest]: mapping[dest][const] = []
+            mapping[dest][const] += action.option_strings
+    return mapping

--- a/coq_tools/find_bug.py
+++ b/coq_tools/find_bug.py
@@ -17,7 +17,7 @@ from .import_util import has_dir_binding, deduplicate_trailing_dir_bindings
 from .memoize import memoize
 from .coq_version import get_coqc_version, get_coqtop_version, get_coqc_help, get_coq_accepts_top, get_coq_native_compiler_ondemand_fragment, group_coq_args, group_coq_args_split_recognized, get_coqc_coqlib, get_coq_accepts_compile, DEFAULT_COQTOP
 from .coq_running_support import get_ltac_support_snippet
-from .custom_arguments import add_libname_arguments, add_passing_libname_arguments, update_env_with_libnames, update_env_with_coqpath_folders, add_logging_arguments, process_logging_arguments, DEFAULT_LOG, LOG_ALWAYS
+from .custom_arguments import add_libname_arguments, add_passing_libname_arguments, update_env_with_libnames, update_env_with_coqpath_folders, add_logging_arguments, process_logging_arguments, get_parser_name_mapping, DEFAULT_LOG, LOG_ALWAYS
 from .binding_util import process_maybe_list
 from .file_util import clean_v_file, read_from_file, write_to_file, restore_file
 from .util import yes_no_prompt, PY3
@@ -1341,6 +1341,7 @@ def main():
         'parse_with': args.parse_with,
         'extra_verbose_prefix': args.verbose_include_failure_warning_prefix,
         'extra_verbose_newline': args.verbose_include_failure_warning_newline,
+        'cli_mapping': get_parser_name_mapping(parser),
         }
 
     if bug_file_name[-2:] != '.v':

--- a/coq_tools/get_admitted_names.py
+++ b/coq_tools/get_admitted_names.py
@@ -8,7 +8,7 @@ from .import_util import lib_of_filename, norm_libname
 from .import_util import has_dir_binding, deduplicate_trailing_dir_bindings
 from .memoize import memoize
 from .coq_version import get_coqc_version, get_coqtop_version, get_coqc_help, get_coq_accepts_top, group_coq_args, DEFAULT_COQTOP
-from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, DEFAULT_LOG, LOG_ALWAYS
+from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, get_parser_name_mapping, DEFAULT_LOG, LOG_ALWAYS
 from .binding_util import process_maybe_list
 from .file_util import clean_v_file, read_from_file, write_to_file, restore_file
 from . import util
@@ -99,6 +99,7 @@ def main():
                            for i in process_maybe_list(args.coq_args, log=args.log)),
         'coqc_is_coqtop': args.coqc_is_coqtop,
         'temp_file_name': '',
+        'cli_mapping': get_parser_name_mapping(parser),
     }
 
     env['remove_temp_file'] = False

--- a/coq_tools/import_util.py
+++ b/coq_tools/import_util.py
@@ -43,6 +43,9 @@ def fill_kwargs(kwargs, for_makefile=False):
         'use_coq_makefile_for_deps' : True,
         'walk_tree'                 : True,
         'coqc_args'                 : tuple(),
+        'cli_mapping'               : {
+            'use_coq_makefile_for_deps' : { False: ['--no-deps'] },
+        },
     }
     rtn.update(kwargs)
     if for_makefile:

--- a/coq_tools/inline_imports.py
+++ b/coq_tools/inline_imports.py
@@ -2,7 +2,7 @@
 import shutil, os, os.path, sys
 from .argparse_compat import argparse
 from .import_util import IMPORT_ABSOLUTIZE_TUPLE, ALL_ABSOLUTIZE_TUPLE
-from .custom_arguments import add_libname_arguments, update_env_with_libnames, update_env_with_coqpath_folders, add_logging_arguments, process_logging_arguments
+from .custom_arguments import add_libname_arguments, update_env_with_libnames, update_env_with_coqpath_folders, add_logging_arguments, process_logging_arguments, get_parser_name_mapping
 from .coq_version import get_coqc_coqlib, DEFAULT_COQTOP
 from .replace_imports import include_imports
 
@@ -66,6 +66,7 @@ def main():
         'coq_makefile': args.coq_makefile,
         'use_coq_makefile_for_deps': args.use_coq_makefile_for_deps,
         'walk_tree': args.walk_tree,
+        'cli_mapping': get_parser_name_mapping(parser),
         }
     update_env_with_libnames(env, args)
     if args.inline_user_contrib: update_env_with_coqpath_folders(env, os.path.join(get_coqc_coqlib(env['coqc'], coq_args=env['coqc_args'], **env), 'user-contrib'))

--- a/coq_tools/memoize.py
+++ b/coq_tools/memoize.py
@@ -3,11 +3,28 @@
 
 __all__ = ["memoize"]
 
+def to_immutable(arg):
+    """Converts a list or dict to an immutable version of itself."""
+    if any(isinstance(arg, ty) for ty in (list, tuple)):
+        return tuple(to_immutable(e) for e in arg)
+    elif isinstance(arg, dict):
+        return tuple((k, to_immutable(arg[k])) for k in sorted(arg.keys()))
+    else:
+        return arg
+
 def memoize(f):
     """ Memoization decorator for a function taking one or more arguments. """
     class memodict(dict):
         def __getitem__(self, *key, **kwkey):
-            return dict.__getitem__(self, (tuple(key), tuple((k, kwkey[k]) for k in sorted(kwkey.keys()))))
+            try:
+                return dict.__getitem__(self, (tuple(key), tuple((k, kwkey[k]) for k in sorted(kwkey.keys()))))
+            except TypeError: # TypeError: unhashable type: 'dict'
+                immutable_key = to_immutable((key, kwkey))
+                if dict.__contains__(self, immutable_key):
+                    return dict.__getitem__(self, immutable_key)
+                else:
+                    self[immutable_key] = ret = f(*key, **kwkey)
+                    return ret
 
         def __missing__(self, key):
             args, kwargs = key

--- a/coq_tools/minimize_requires.py
+++ b/coq_tools/minimize_requires.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 import shutil, os, os.path, sys, re
 from .argparse_compat import argparse
-from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, LOG_ALWAYS, DEFAULT_VERBOSITY
+from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, get_parser_name_mapping, LOG_ALWAYS, DEFAULT_VERBOSITY
 from .split_file import UnsupportedCoqVersionError
 from .import_util import get_file_statements_insert_references, sort_files_by_dependency, classify_require_kind, EXPORT, REQUIRE_EXPORT
 from .file_util import write_to_file
@@ -157,6 +157,7 @@ def main():
         'inplace': args.suffix != '', # it's None if they passed no argument, and '' if they didn't pass -i
         'suffix': args.suffix,
         'input_files': tuple(f.name for f in args.input_files),
+        'cli_mapping': get_parser_name_mapping(parser),
         }
     update_env_with_libnames(env, args)
 

--- a/coq_tools/move_requires.py
+++ b/coq_tools/move_requires.py
@@ -2,6 +2,7 @@
 from __future__ import with_statement
 import os, sys, shutil, re
 from .argparse_compat import argparse
+from .custom_arguments import get_parser_name_mapping
 
 __all__ = ['main']
 
@@ -82,6 +83,7 @@ def main():
         'log': log,
         'inplace': args.suffix != '', # it's None if they passed no argument, and '' if they didn't pass -i
         'suffix': args.suffix,
+        'cli_mapping': get_parser_name_mapping(parser),
         }
 
     for f in args.input_files:

--- a/coq_tools/move_vernaculars.py
+++ b/coq_tools/move_vernaculars.py
@@ -4,7 +4,7 @@ import os, sys, shutil, re
 from .argparse_compat import argparse
 from .split_file import split_coq_file_contents_with_comments
 from .strip_comments import strip_comments
-from .custom_arguments import add_logging_arguments, process_logging_arguments, LOG_ALWAYS
+from .custom_arguments import add_logging_arguments, process_logging_arguments, get_parser_name_mapping, LOG_ALWAYS
 from .file_util import write_to_file
 from .util import PY3
 if PY3: from .util import raw_input
@@ -201,6 +201,7 @@ def main():
         'log': args.log,
         'inplace': args.suffix != '', # it's None if they passed no argument, and '' if they didn't pass -i
         'suffix': args.suffix,
+        'cli_mapping': get_parser_name_mapping(parser),
         }
 
     for f in args.input_files:

--- a/coq_tools/proof_using_helper.py
+++ b/coq_tools/proof_using_helper.py
@@ -2,7 +2,7 @@
 from __future__ import with_statement
 import os, sys, re
 from .argparse_compat import argparse
-from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, LOG_ALWAYS
+from .custom_arguments import add_libname_arguments, update_env_with_libnames, add_logging_arguments, process_logging_arguments, get_parser_name_mapping, LOG_ALWAYS
 from .memoize import memoize
 from .file_util import read_from_file, write_to_file
 
@@ -234,7 +234,8 @@ def main():
     env = {
         'lib_to_dir': lib_to_dir_map(args.libnames + args.non_recursive_libnames),
         'log': args.log,
-        'hide_reg': args.hide_reg
+        'hide_reg': args.hide_reg,
+        'cli_mapping': get_parser_name_mapping(parser),
         }
     update_env_with_libnames(env, args)
     for theorem_id, suggestions in REG_PROOF_USING.findall('\n'.join(source)):


### PR DESCRIPTION
As per
https://github.com/JasonGross/coq-tools/issues/176#issuecomment-1777726114, https://github.com/JasonGross/coq-tools/issues/176#issuecomment-1777764511, and
https://github.com/JasonGross/coq-tools/issues/176#issuecomment-1781782890.

I need to figure out how to do `tee`-like subprocess.Popen, so that we can both pipe the output of `make` (though maybe it doesn't need to be real-time?) and check the errors.