### PR TITLE
Add `--[no-]recursive-requires-explicit`

### DIFF
--- a/coq_tools/find_bug.py
+++ b/coq_tools/find_bug.py
@@ -589,6 +589,12 @@ parser.add_argument(
 )
 parser.add_argument("--remove-comments", action=BooleanOptionalAction, default=None, help="Remove all comments.")
 parser.add_argument("--normalize-requires", action=BooleanOptionalAction, default=True, help="Normalize requires.")
+parser.add_argument(
+    "--recursive-requires-explicit",
+    action=BooleanOptionalAction,
+    default=None,
+    help="When normalizing requires, include all recursive requires explicitly.  This is useful for removing unneeded intermediate requires rather than inlining them, but causes issues with minimization when requires are not pre-emptively removed if any require fails to inline.",
+)
 parser.add_argument("--split-requires", action=BooleanOptionalAction, default=True, help="Split requires.")
 parser.add_argument("--remove-hints", action=BooleanOptionalAction, default=None, help="Remove all hints.")
 parser.add_argument(
@@ -643,6 +649,7 @@ def adjust_no_error_defaults(args: argparse.Namespace):
         "admit_transparent",
         "admit_obligations",
         "split_imports",
+        "recursive_requires_explicit",
     ):
         if getattr(args, arg) is None:
             setattr(args, arg, not args.should_succeed)
@@ -2886,6 +2893,7 @@ def main():
         "remove_sections": args.remove_sections,
         "remove_comments": args.remove_comments,
         "normalize_requires": args.normalize_requires,
+        "recursive_requires_explicit": args.recursive_requires_explicit,
         "split_requires": args.split_requires,
         "remove_hints": args.remove_hints,
         "remove_empty_sections": args.remove_empty_sections,

--- a/coq_tools/import_util.py
+++ b/coq_tools/import_util.py
@@ -43,6 +43,7 @@ __all__ = [
     "ALL_ABSOLUTIZE_TUPLE",
     "absolutize_has_all_constants",
     "run_recursively_get_imports",
+    "run_maybe_recursively_get_imports",
     "clear_libimport_cache",
     "get_byte_references_for",
     "sort_files_by_dependency",
@@ -1255,6 +1256,16 @@ def run_recursively_get_imports(lib, recur=recursively_get_imports, fast=False, 
         imports_list = [recur(k, fast=fast, **kwargs) for k in imports]
         return merge_imports(tuple(map(tuple, imports_list + [[lib]])), **kwargs)
     return [lib]
+
+
+def run_maybe_recursively_get_imports(lib, recursively: bool = True, **kwargs):
+    recursive_imports = run_recursively_get_imports(lib, **kwargs)
+    if recursively:
+        return recursive_imports
+    else:
+        # keep the order of the recursive version, but only keep the elements in the non-recursive list
+        direct_imports = run_recursively_get_imports(lib, recur=lambda lib, **_kwargs: [lib], **kwargs)
+        return [lib for lib in recursive_imports if lib in direct_imports]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This should result in better outputs when not all modules can be inlined.

Supersedes #277
Closes #277