### PR TITLE
Take longer .glob file when passing coqc can't find libraries

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -9,6 +9,8 @@ CONDITIONAL_TESTS = 006 018
 
 ONLY_IF_COQTOP_COMPILE_TESTS =
 ONLY_IF_Q_TESTS = 010 026
+ONLY_IF_TYPE_IN_TYPE_WORKS_TESTS =
+ONLY_IF_Q_AND_TYPE_IN_TYPE_WORKS_TESTS = 073
 ONLY_IF_TOP_TESTS = 063
 ONLY_IF_PROOF_USING_TESTS = 067 069
 ONLY_IF_W_TESTS = 044
@@ -26,6 +28,8 @@ ONLY_IF_SYS_GLOB_FILES_GOOD_AND_CAN_INLINE_COQ_INIT_LOGIC_TESTS = 056
 ONLY_IF_CUSTOM_ENTRY_TESTS = 070
 CONDITIONAL_TESTS += \
 	$(ONLY_IF_Q_TESTS) \
+	$(ONLY_IF_TYPE_IN_TYPE_WORKS_TESTS) \
+	$(ONLY_IF_Q_AND_TYPE_IN_TYPE_WORKS_TESTS) \
 	$(ONLY_IF_TOP_TESTS) \
 	$(ONLY_IF_PROOF_USING_TESTS) \
 	$(ONLY_IF_W_TESTS) \
@@ -53,6 +57,8 @@ BROKEN_LOGS = $(patsubst %,example_%_result.log,$(BROKEN_TESTS))
 ALL_LOGS = $(DEFAULT_LOGS) $(CONDITIONAL_LOGS) $(BROKEN_LOGS)
 ONLY_IF_COQTOP_COMPILE_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_COQTOP_COMPILE_TESTS))
 ONLY_IF_Q_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_Q_TESTS))
+ONLY_IF_TYPE_IN_TYPE_WORKS_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_TYPE_IN_TYPE_WORKS_TESTS))
+ONLY_IF_Q_AND_TYPE_IN_TYPE_WORKS_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_Q_AND_TYPE_IN_TYPE_WORKS_TESTS))
 ONLY_IF_TOP_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_TOP_TESTS))
 ONLY_IF_PROOF_USING_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_PROOF_USING_TESTS))
 ONLY_IF_W_LOGS = $(patsubst %,example_%_result.log,$(ONLY_IF_W_TESTS))
@@ -119,6 +125,7 @@ COQC_SUPPORTS_IMPORT_CATEGORIES:=$(shell echo "Require Import (hints) Coq.Init.N
 COQC_SUPPORTS_W:=$(shell $(COQBIN)coqtop --help 2>&1 | grep -c -- '-w ')
 COQC_SUPPORTS_VOS:=$(shell $(COQBIN)coqc --help 2>&1 | grep -c -- '-vos ')
 COQC_SUPPORTS_UNSET:=$(shell $(COQBIN)coqtop --help 2>&1 | grep -c -- '-unset ')
+COQC_TYPE_IN_TYPE_WORKS:=$(shell printf "Check Set : Set." | $(COQBIN)coqtop -type-in-type 2>&1 | grep -q 'Error'; echo $$?)
 COQC_COQLIB:=$(shell $(COQBIN)coqc -config 2>&1 | grep -o 'COQLIB=.*' | sed s'/^COQLIB=//g')
 COQLIB_V_FILES:=$(wildcard $(COQC_COQLIB)/theories/Init/*.v)
 COQLIB_GLOB_FILES:=$(wildcard $(COQC_COQLIB)/theories/Init/*.glob)
@@ -168,6 +175,21 @@ else
 print-support::
 	@printf "coqc supports -Q:\t\t\t\tNo\n"
 endif
+
+ifneq (0,$(strip $(COQC_TYPE_IN_TYPE_WORKS)))
+test-suite: $(ONLY_IF_TYPE_IN_TYPE_WORKS_LOGS)
+ENABLED_LOGS += $(ONLY_IF_TYPE_IN_TYPE_WORKS_LOGS)
+print-support::
+	@printf "coqc supports Set:Set with -type-in-type:\tYes\n"
+ifneq (0,$(strip $(COQC_SUPPORTS_Q)))
+test-suite: $(ONLY_IF_Q_AND_TYPE_IN_TYPE_WORKS_LOGS)
+ENABLED_LOGS += $(ONLY_IF_Q_AND_TYPE_IN_TYPE_WORKS_LOGS)
+endif
+else
+print-support::
+	@printf "coqc supports Set:Set with -type-in-type:\tNo\n"
+endif
+
 
 ifneq (0,$(strip $(COQC_SUPPORTS_PROOF_USING)))
 print-support::

--- a/examples/example_073/Bar/Foo.v
+++ b/examples/example_073/Bar/Foo.v
@@ -1,0 +1,1 @@
+Definition A := Set.

--- a/examples/example_073/example_073.v
+++ b/examples/example_073/example_073.v
@@ -1,0 +1,2 @@
+Require Import Foo.
+Check A : Set.

--- a/examples/run-example-073.sh
+++ b/examples/run-example-073.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+###################################################################
+## Test glob file generation when passing and failing coqc      ##
+## use different library binding types (-Q vs -R)                ##
+## to demonstrate the fix for issue #296                         ##
+###################################################################
+
+##########################################################
+# Various options that must be updated for each example
+N="${0##*-}"; N="${N%.sh}"
+EXAMPLE_DIRECTORY="example_$N"
+EXAMPLE_INPUT="example_$N.v"
+EXAMPLE_OUTPUT="bug_$N.v"
+# passing coqc gets -Q binding, failing coqc gets -R binding
+# This mimics the situation where passing dev has installed lib, failing dev has local lib
+EXTRA_ARGS=(--passing-coqc="${COQBIN}coqc" --passing-arg=-type-in-type --passing-Q . Qux --nonpassing-R . Qux --no-deps "$@")
+##########################################################
+
+# Get the directory name of this script, and `cd` to that directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR/$EXAMPLE_DIRECTORY" || exit $?
+
+# Initialize common settings like the version of python
+. "$DIR/init-settings.sh"
+
+
+
+# Set up bash to be verbose about displaying the commands run
+PS4='$ '
+set -x
+
+# Disable parallel make in subcalls to the bug minimizer because it screws with things
+. "$DIR/disable-parallel-make.sh"
+
+######################################################################
+# Create the output file (to normalize the number of "yes"es needed),
+# and run the script only up to the request for the regular
+# expression; then test that the output is as expected.
+#
+# If you don't need to test the output of the initial requests, feel
+# free to remove this section.
+#
+# Note that the -top argument only appears in Coq >= 8.4
+#
+# Note also that the line numbers tend to be one larger in old
+# versions of Coq (<= 8.6?)
+{ EXPECTED_ERROR=$(cat); } <<EOF
+File "[^"]*\.v", line [0-9]\+, characters 6-7:
+Error:
+The term "A" has type "Type" while it is expected to have type
+EOF
+
+# pre-build the files to normalize the output for the run we're testing
+find "$DIR/$EXAMPLE_DIRECTORY" \( -name "*.vo" -o -name "*.glob" \) -delete
+# Pre-compile the library file with -R so failing coqc can find it
+"${COQBIN}coqc" -q -R . Qux Bar/Foo.v
+echo "y" | find_bug "$EXAMPLE_INPUT" "$EXAMPLE_OUTPUT" "${EXTRA_ARGS[@]}" 2>/dev/null >/dev/null
+# kludge: create the .glob file so we don't run the makefile
+touch "${EXAMPLE_OUTPUT%%.v}.glob"
+ACTUAL_PRE="$( (echo "y"; echo "y") | find_bug "$EXAMPLE_INPUT" "$EXAMPLE_OUTPUT" "${EXTRA_ARGS[@]}" -l - 2>&1)"
+ACTUAL_PRE_ONE_LINE="$(strip_for_grep "$ACTUAL_PRE")"
+TEST_FOR="$(strip_for_grep "$EXPECTED_ERROR")"
+if ! grep_contains "$ACTUAL_PRE_ONE_LINE" "$TEST_FOR"
+then
+    echo "Expected a string matching:"
+    echo "$EXPECTED_ERROR"
+    echo
+    echo
+    echo
+    echo "Actual:"
+    echo "$ACTUAL_PRE"
+    PREFIX_GREP="$(relpath "$DIR/prefix-grep.py" "$PWD")"
+    ${PYTHON} "$PREFIX_GREP" "$ACTUAL_PRE_ONE_LINE" "$TEST_FOR"
+    exit 1
+fi
+#########################################################################################################
+
+
+#####################################################################
+# Run the bug minimizer on this example; error if it fails to run
+# correctly.  Make sure you update the arguments, etc.
+find_bug "$EXAMPLE_INPUT" "$EXAMPLE_OUTPUT" "${EXTRA_ARGS[@]}" || exit $?
+
+######################################################################
+# Put some segment that you expect to see in the file here.  Or count
+# the number of lines.  Or make some other test.  Or remove this block
+# entirely if you don't care about the minimized file.
+{ EXPECTED=$(cat); } <<EOF
+(\* -\*- mode: coq; coq-prog-args: ("-emacs"\( "-w" "-deprecated-native-compiler-option,-native-compiler-disabled"\)\?\( "-native-compiler" "ondemand"\)\? "-R" "." "Qux"\( "-top" "Qux\.example_[0-9]\+"\)\?) -\*- \*)
+(\* File reduced by coq-bug-minimizer from original input\(, then from [0-9]\+ lines to [0-9]\+ lines\)\+ \*)
+(\* coqc version [^\*]*\*)
+
+Definition A := Set\.
+Check A : Set\.
+
+EOF
+
+EXPECTED_ONE_LINE="$(strip_for_grep "$EXPECTED")"
+ACTUAL="$(strip_for_grep "$(cat "$EXAMPLE_OUTPUT")")"
+if ! grep_contains "$ACTUAL" "$EXPECTED_ONE_LINE"
+then
+    echo "Expected a string matching:"
+    echo "$EXPECTED"
+    echo "Got:"
+    cat "$EXAMPLE_OUTPUT" | grep -v '^$'
+    PREFIX_GREP="$(relpath "$DIR/prefix-grep.py" "$PWD")"
+    ${PYTHON} "$PREFIX_GREP" "$ACTUAL" "$EXPECTED_ONE_LINE"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Fix #296: When passing coqc uses -Q bindings but can't find the required libraries (e.g., due to not uploading _build_ci), it generates shorter .glob files missing qualifications. This fix compares glob files from both passing and failing coqc and takes the longer one.

Adds example 068 to test this scenario.