### PR TITLE
Sort requires by component when normalizing

### DIFF
--- a/coq_tools/find_bug.py
+++ b/coq_tools/find_bug.py
@@ -284,6 +284,13 @@ parser.add_argument(
     ),
 )
 parser.add_argument(
+    "--sort-requires-by-component",
+    dest="sort_requires_by_component",
+    action=BooleanOptionalAction,
+    default=True,
+    help=("Sort Requires by component."),
+)
+parser.add_argument(
     "--no-deps",
     dest="use_coq_makefile_for_deps",
     action="store_const",
@@ -3541,7 +3548,7 @@ def inline_one_require(
         if include_options_settings or without_require:
             all_imports = get_recursive_require_names(
                 req_module, reverse=False, **kwargs
-            )  # like run_recursively_get_imports, but get_recursive_require_names also strips off the self module
+            )  # like recursively_get_imports, but get_recursive_require_names also strips off the self module
             require_statements = "".join("Require %s.\n" % i for i in all_imports)
             if without_require:
                 require_statements_before_replacement = "\n" + require_statements
@@ -3998,6 +4005,7 @@ def main():
         "remove_abort": args.remove_abort,
         "remove_ltac": args.remove_ltac,
         "remove_section_variables": args.remove_section_variables,
+        "sort_requires_by_component": args.sort_requires_by_component,
         "prefer_inline_via_include": args.prefer_inline_via_include,
         "export_modules": args.export_modules,
         "split_imports": args.split_imports,

--- a/coq_tools/replace_imports.py
+++ b/coq_tools/replace_imports.py
@@ -5,8 +5,6 @@ from .import_util import (
     filename_of_lib,
     lib_of_filename,
     get_file,
-    run_recursively_get_imports,
-    run_maybe_recursively_get_imports,
     recursively_get_imports,
     absolutize_has_all_constants,
     is_local_import,
@@ -211,7 +209,7 @@ def normalize_requires(filename, recursive_requires_explicit: bool = True, **kwa
         filename += ".v"
     kwargs = fill_kwargs(kwargs)
     lib = lib_of_filename(filename, **kwargs)
-    all_imports = run_maybe_recursively_get_imports(lib, recursively=recursive_requires_explicit, **kwargs)
+    all_imports = recursively_get_imports(lib, recursively=recursive_requires_explicit, **kwargs)
 
     v_name = filename_of_lib(lib, ext=".v", **kwargs)
     contents = get_file(v_name, **kwargs)
@@ -230,7 +228,7 @@ def recursively_get_requires_from_file(filename, **kwargs):
         filename += ".v"
     kwargs = fill_kwargs(kwargs)
     lib = lib_of_filename(filename, **kwargs)
-    return tuple(run_recursively_get_imports(lib, **kwargs)[:-1])
+    return tuple(recursively_get_imports(lib, **kwargs)[:-1])
 
 
 def include_imports(filename, as_modules=True, absolutize=ALL_ABSOLUTIZE_TUPLE, **kwargs):

--- a/coq_tools/util.py
+++ b/coq_tools/util.py
@@ -3,7 +3,7 @@ import re
 import sys
 from collections import defaultdict
 from difflib import SequenceMatcher
-from typing import Dict, Hashable, Iterable, List, Set, TypeVar
+from typing import Any, Dict, Generic, Hashable, Iterable, List, Set, TypeVar, Protocol
 
 from .argparse_compat import argparse
 
@@ -78,6 +78,7 @@ cmp_compat = cmp
 
 K = TypeVar("K")
 V = TypeVar("V")
+T = TypeVar("T")
 TH = TypeVar("TH", bound=Hashable)
 
 
@@ -299,8 +300,16 @@ def list_diff(
     return "\n".join(diff_lines)
 
 
+class TransitiveClosureDict(Generic[TH], Protocol):
+    def __getitem__(self, key: TH, /) -> Iterable[TH]: ...
+
+    def keys(self) -> Iterable[TH]: ...
+
+    def values(self) -> Iterable[Iterable[TH]]: ...
+
+
 def transitive_closure(
-    graph: Dict[TH, Iterable[TH]],
+    graph: TransitiveClosureDict[TH],
 ) -> Dict[TH, Set[TH]]:
     """
     Computes the transitive closure of a directed graph represented as an adjacency list.


### PR DESCRIPTION
TODO: We want to preserve the default ordering from files in other
cases, by default, and as a fallback.