### PR TITLE
Add native Python coqchk support to find_bug.py

### DIFF
--- a/coq_tools/custom_arguments.py
+++ b/coq_tools/custom_arguments.py
@@ -413,7 +413,7 @@ def argstring_to_iterable(arg):
 
 
 def append_coq_arg(env, arg, passing=""):
-    for key in ("coqc_args", "coqtop_args"):
+    for key in ("coqc_args", "coqtop_args", "coqchk_args"):
         env[passing + key] = tuple(
             list(env.get(passing + key, [])) + list(argstring_to_iterable(arg))
         )


### PR DESCRIPTION
- Add get_coqchk_help and get_coqchk_version functions to coq_version.py
- Add coqchk_prog and coqchk_prog_args parameters to get_coq_output in diagnose_error.py
- Process coqchk output with Fatal Error handling
- Add --coqchk-args, --nonpassing-coqchk-args, --passing-coqchk-args CLI options
- Set coqchk/passing_coqchk to None when --chk is not specified
- Pass coqchk_prog and coqchk_prog_args explicitly to all get_coq_output calls
- Extend argument processing loops to handle coqchk args similar to coqtop