### PR TITLE
Fix SyntaxWarning: invalid escape sequence in regex strings

### DIFF
--- a/coq_tools/move_vernaculars.py
+++ b/coq_tools/move_vernaculars.py
@@ -83,9 +83,9 @@ def set_leading_space(string, space_count):
 
 def strip_parens(string):
     last = string
-    cur = re.sub('"[^"]+|{[^{}]+}|\([^\(\)]+\)', "", last)
+    cur = re.sub(r'"[^"]+|{[^{}]+}|\([^\(\)]+\)', "", last)
     while cur != last:
-        last, cur = cur, re.sub('"[^"]+|{[^{}]+}|\([^\(\)]+\)', "", cur)
+        last, cur = cur, re.sub(r'"[^"]+|{[^{}]+}|\([^\(\)]+\)', "", cur)
     cur = re.sub(r'\slet\s[^\(\){}"]+?:=[^\(\){}"]+?\sin\s', "", cur, re.MULTILINE)
     return cur
 

--- a/coq_tools/proof_using_helper.py
+++ b/coq_tools/proof_using_helper.py
@@ -166,7 +166,7 @@ FOUND_BUT_UNCHANGED = object()
 
 
 def get_indent(term):
-    return re.findall("^\s*", term)[0]
+    return re.findall(r"^\s*", term)[0]
 
 
 COMMENT = "comment"
@@ -213,7 +213,7 @@ def update_proof(name, before_match, match, after_match, filename, rest_id, sugg
         proof_part = after_match[: ending.start()]
         env["log"]("Inspecting proof: %s" % proof_part, level=2)
         if proof_part.count("Proof") == 1:
-            proof_match = re.search("Proof(?: using[^\.]*)?\.", proof_part)
+            proof_match = re.search(r"Proof(?: using[^\.]*)?\.", proof_part)
             if proof_match:
                 if proof_match.group() == suggestion:
                     return FOUND_BUT_UNCHANGED  # already correct


### PR DESCRIPTION
Fixes #420.

Adds `r` prefix to regex pattern strings in `coq_tools/move_vernaculars.py` and `coq_tools/proof_using_helper.py` so Python 3.12+ no longer emits `SyntaxWarning: invalid escape sequence` when importing the package.

Behavior is unchanged: the byte-level string contents are identical, since the unrecognized escapes (`\(`, `\s`, `\.`) were already being treated as literal backslash + character.