### PR TITLE
Fix coqchk minimization: keep load-path args, and don't delete the glob for temp-dir .v files

### DIFF
--- a/coq_tools/coq_version.py
+++ b/coq_tools/coq_version.py
@@ -86,8 +86,12 @@ def get_coqc_help(coqc_prog, **kwargs):
 
 def get_coqchk_help(coqchk_prog, **kwargs):
     assert isinstance(coqchk_prog, tuple), coqchk_prog
-    (stdout, _stderr), _rc = subprocess_Popen_memoized([*coqchk_prog, "-h"], **kwargs)
-    return util.s(stdout).strip()
+    # coqchk does not accept `-q --help`; its option is `-h`, and it prints its
+    # usage to stderr rather than stdout, so we must capture and include stderr.
+    (stdout, stderr), _rc = subprocess_Popen_memoized(
+        [*coqchk_prog, "-h"], stderr=subprocess.PIPE, **kwargs
+    )
+    return (util.s(stdout) + "\n" + util.s(stderr)).strip()
 
 
 def coqlib_args(coqc_prog_coqlib=None):

--- a/coq_tools/find_bug.py
+++ b/coq_tools/find_bug.py
@@ -26,6 +26,7 @@ from .coq_version import (
     get_coq_native_compiler_ondemand_fragment,
     get_coqc_coqlib,
     get_coqc_help,
+    get_coqchk_help,
     get_coqc_version,
     get_coqtop_version,
     group_coq_args,
@@ -4790,7 +4791,14 @@ def main():
             else ()
         ):
             coqc_prog_help = get_coqc_help(coqc_prog, **env)
-            coqtop_prog_help = get_coqc_help(coqtop_prog, **env)
+            # coqchk has its own option set and does not accept `-q --help`, so
+            # we must query it with the coqchk-specific helper; otherwise its
+            # help comes back empty and shared options like -Q/-R/-I get
+            # mistakenly stripped as "coqc-only".
+            if "coqchk" in coqprog:
+                coqtop_prog_help = get_coqchk_help(coqtop_prog, **env)
+            else:
+                coqtop_prog_help = get_coqc_help(coqtop_prog, **env)
             # we want to skip any arguments that are recognized by coqc but not coqtop
             recognized_args, unrecognized_args = group_coq_args_split_recognized(
                 env[args_name], coqtop_prog_help

--- a/coq_tools/import_util.py
+++ b/coq_tools/import_util.py
@@ -787,6 +787,14 @@ def make_one_glob_file_helper(
         tempfile.gettempdir(), os.path.basename(v_file_root) + ".glob"
     )
     glob_file = v_file_root + ".glob"
+    # When the .v file lives in the system temp dir, tmp_glob_file and glob_file
+    # resolve to the same file.  In that case coqc dumps the glob directly to
+    # its final location, so we must neither "move" it onto itself nor delete it
+    # during cleanup below; doing the latter previously produced a spurious
+    # FileNotFoundError when the glob was read back.
+    glob_file_is_tmp_glob_file = os.path.realpath(tmp_glob_file) == os.path.realpath(
+        glob_file
+    )
     if get_coq_accepts_o(coqc_prog, **kwargs):
         cmds += ["-o", o_file]
     else:
@@ -838,13 +846,14 @@ def make_one_glob_file_helper(
                 )
             else:
                 kwargs["log"](f"Moving '{tmp_glob_file}' to '{glob_file}'")
-            try:
-                # N.B. We need shutil.move rather than os.rename because the source and destination may be on different filesystems
-                shutil.move(tmp_glob_file, glob_file)
-            except PermissionError as e:
-                kwargs["log"](
-                    f"Failed to move '{tmp_glob_file}' to '{glob_file}' ({e}), assuming that '{glob_file}' is up to date"
-                )
+            if not glob_file_is_tmp_glob_file:
+                try:
+                    # N.B. We need shutil.move rather than os.rename because the source and destination may be on different filesystems
+                    shutil.move(tmp_glob_file, glob_file)
+                except PermissionError as e:
+                    kwargs["log"](
+                        f"Failed to move '{tmp_glob_file}' to '{glob_file}' ({e}), assuming that '{glob_file}' is up to date"
+                    )
         elif os.path.exists(tmp_glob_file):
             kwargs["log"](
                 f"WARNING: Not clobbering '{glob_file}' ({os.path.getmtime(glob_file)}) because coqc failed on '{v_file}' ({os.path.getmtime(v_file_root + ext)})",
@@ -854,7 +863,10 @@ def make_one_glob_file_helper(
     finally:
         if os.path.exists(o_file):
             os.remove(o_file)
-        if os.path.exists(tmp_glob_file):
+        # Do not delete the glob if tmp_glob_file is the final glob_file (which
+        # happens when the .v file is in the system temp dir); that would remove
+        # the very glob we just generated.
+        if os.path.exists(tmp_glob_file) and not glob_file_is_tmp_glob_file:
             os.remove(tmp_glob_file)
 
 

--- a/tests/test_coqchk_args.py
+++ b/tests/test_coqchk_args.py
@@ -1,0 +1,111 @@
+"""Regression tests for coqchk argument handling.
+
+These guard against the bug where shared load-path options (-Q/-R/-I/-coqlib)
+were stripped from the coqchk command line because coqchk's --help was queried
+the same way as coqc's (`-q --help`), which coqchk rejects, yielding an empty
+help string and causing those options to be misclassified as "coqc-only".
+
+See https://github.com/rocq-community/run-coq-bug-minimizer/issues/53 and the
+discussion on https://github.com/rocq-prover/rocq/issues/22125.
+"""
+
+from coq_tools.coq_version import (
+    get_multiple_help_tags,
+    get_single_help_tags,
+    group_coq_args_split_recognized,
+)
+
+# coqchk's actual usage text (see checker/coqchk_main.ml print_usage_channel).
+COQCHK_HELP = """Usage: coqchk <options> modules
+
+coqchk options are:
+
+  -Q dir coqdir               map physical dir to logical coqdir
+  -R dir coqdir               synonymous for -Q
+  -coqlib dir                 set coqchk's standard library location
+  -boot                       don't initialize the library paths automatically
+
+  -admit module               load module and dependencies without checking
+  -norec module               check module but admit dependencies without checking
+
+  -d (d1,..,dn)               enable specified debug messages
+  -debug                      enable all debug messages
+  -profile file               output profiling info to file
+  -where                      print coqchk's standard library location and exit
+  -v, --version               print coqchk version and exit
+  -o, --output-context        print the list of assumptions
+  -m, --memory                print the maximum heap size
+  -silent                     disable trace of constants being checked
+
+  -impredicative-set          set sort Set impredicative
+  -indices-matter             levels of indices (and nonuniform parameters)
+  -bytecode-compiler (yes|no) enable the vm_compute reduction machine (default is no)
+
+  -h, --help                  print this list of options
+"""
+
+# An abbreviated coqc help, enough to recognize the coqc-only options used below.
+COQC_HELP = """  -Q dir coqdir          recursively map
+  -R dir coqdir          map
+  -I dir                 ml include
+  -coqlib dir            set coqlib
+  -w w                   configure warnings
+  -native-compiler arg   native compilation
+  -top coqdir            set the toplevel name
+"""
+
+
+def test_coqchk_help_recognizes_load_path_options():
+    multiple = get_multiple_help_tags(COQCHK_HELP)
+    single = get_single_help_tags(COQCHK_HELP)
+    assert multiple.get("-Q") == 3
+    assert multiple.get("-R") == 3
+    assert multiple.get("-coqlib") == 2
+    assert multiple.get("-admit") == 2
+    assert "-silent" in single
+    assert "-boot" in single
+
+
+def _filter_like_find_bug(args, coqchk_help, coqc_help):
+    """Mirror the two-stage filtering done in find_bug.py for coqchk args."""
+    recognized, unrecognized = group_coq_args_split_recognized(args, coqchk_help)
+    coqc_only, unrecognized = group_coq_args_split_recognized(unrecognized, coqc_help)
+    return [arg for group in recognized for arg in group] + unrecognized, coqc_only
+
+
+def test_load_path_options_survive_filtering():
+    args = [
+        "-coqlib", "/lib/coq/",
+        "-w", "-foo",
+        "-native-compiler", "ondemand",
+        "-top", "MyMod",
+        "-Q", "/p/Coqprime", "Coqprime",
+        "-R", "/p/Bignums", "Bignums",
+        "-silent",
+    ]
+    final, coqc_only = _filter_like_find_bug(args, COQCHK_HELP, COQC_HELP)
+    # shared load-path / kernel options must be kept
+    assert "-Q" in final and "Coqprime" in final
+    assert "-R" in final and "Bignums" in final
+    assert final[:2] == ["-coqlib", "/lib/coq/"]
+    assert "-silent" in final
+    # coqc-only options must still be stripped (coqchk would reject them)
+    assert "-w" not in final
+    assert "-native-compiler" not in final
+    assert "-top" not in final
+    assert ("-w", "-foo") in coqc_only
+    assert ("-top", "MyMod") in coqc_only
+
+
+def test_empty_help_would_drop_load_path_regression():
+    """With empty coqchk help (the old buggy behavior), -Q/-R get dropped.
+
+    This documents the failure mode the fix avoids: when coqchk's help is
+    empty, only the hard-coded -coqlib survives and -Q/-R are misclassified as
+    coqc-only.
+    """
+    args = ["-Q", "/p/Coqprime", "Coqprime", "-R", "/p/Bignums", "Bignums"]
+    final, coqc_only = _filter_like_find_bug(args, "", COQC_HELP)
+    assert "-Q" not in final
+    assert "-R" not in final
+    assert ("-Q", "/p/Coqprime", "Coqprime") in coqc_only

--- a/tests/test_glob_tmpdir.py
+++ b/tests/test_glob_tmpdir.py
@@ -1,0 +1,84 @@
+"""Regression test for glob generation when the .v file lives in the temp dir.
+
+When the input .v file is directly inside ``tempfile.gettempdir()``, the
+temporary glob path (``gettempdir()/<base>.glob``) and the final glob path
+(``<v_file_root>.glob``) are the same file.  A bug in make_one_glob_file_helper
+then deleted that single glob in its ``finally`` cleanup, so reading it back
+raised ``FileNotFoundError``.  This reproduces the failure seen while wiring
+coqchk into the bug minimizer (the bug file was created in /tmp); see
+https://github.com/rocq-prover/rocq/issues/22125.
+"""
+
+import os
+import stat
+import tempfile
+
+from coq_tools import import_util
+
+FAKE_COQC = """#!/usr/bin/env python3
+import sys
+
+args = sys.argv[1:]
+if "-h" in args or "--help" in args:
+    sys.stdout.write(
+        "Usage:\\n"
+        "  -q\\n"
+        "  -boot\\n"
+        "  -nois\\n"
+        "  -o f\\toutput file\\n"
+        "  -dump-glob f\\tdump glob\\n"
+        "  -Q dir coqdir\\tmap\\n"
+        "  -R dir coqdir\\tmap\\n"
+        "  -coqlib dir\\tset\\n"
+    )
+    sys.exit(0)
+if "-dump-glob" in args:
+    g = args[args.index("-dump-glob") + 1]
+    with open(g, "w") as f:
+        f.write("DUMMY GLOB\\n")
+sys.exit(0)
+"""
+
+
+def _make_fake_coqc(dirname):
+    path = os.path.join(dirname, "fake_coqc")
+    with open(path, "w") as f:
+        f.write(FAKE_COQC)
+    os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def test_glob_preserved_for_v_file_directly_in_tmpdir():
+    bindir = tempfile.mkdtemp()
+    fake_coqc = _make_fake_coqc(bindir)
+
+    # The .v file must be created *directly* in gettempdir() to trigger the
+    # tmp_glob_file == glob_file collision.
+    fd, v_file = tempfile.mkstemp(
+        suffix=".v", prefix="coqchkminimizer_test_", dir=tempfile.gettempdir()
+    )
+    os.close(fd)
+    with open(v_file, "w") as f:
+        f.write("(* test file *)\n")
+    glob_file = os.path.splitext(v_file)[0] + ".glob"
+    vo_file = os.path.splitext(v_file)[0] + ".vo"
+
+    try:
+        import_util.make_one_glob_file(
+            v_file,
+            coqc=(fake_coqc,),
+            libnames=(),
+            non_recursive_libnames=(),
+            ocaml_dirnames=(),
+            walk_tree=False,
+            use_coq_makefile_for_deps=False,
+        )
+        # The bug deleted the glob in cleanup; it must survive and be readable.
+        assert os.path.exists(glob_file), "glob file was deleted during cleanup"
+        with open(glob_file) as f:
+            assert "DUMMY GLOB" in f.read()
+    finally:
+        for p in (v_file, glob_file, vo_file, fake_coqc):
+            if os.path.exists(p):
+                os.remove(p)
+        os.rmdir(bindir)


### PR DESCRIPTION
Two bugs that broke minimizing `coqchk` / `rocq check` failures, both reproduced from the logs of rocq-prover/rocq#22125 (bug minimizer fed a `/tmp/coqchkminimizer*.v` file `Require`-ing the failing module).

## 1. Load-path args (`-Q`/`-R`/`-I`) dropped from the coqchk command line

`find_bug.py` filters each program's args by querying its `--help` and dropping options the target program doesn't accept. For coqchk it used `get_coqc_help`, which runs `<prog> -q --help` — but **coqchk rejects `-q`** (`Fatal Error: Unknown option -q`, confirmed in the run's `bug.log`), so its help came back empty, and `-Q`/`-R`/`-I` were misclassified as "coqc-only" and stripped (only `-coqlib` survived, because it's hard-coded). coqchk then couldn't find the libraries to check.

Fix:
- `get_coqchk_help`: coqchk prints its usage to **stderr** in response to `-h`, so capture and include stderr (was reading only stdout → empty).
- `find_bug.py`: use `get_coqchk_help` (not `get_coqc_help`) when filtering `coqchk_args` / `passing_coqchk_args`.

Result: coqchk keeps `-Q`/`-R`/`-coqlib`/`-silent`/… while genuine coqc-only flags (`-w`, `-native-compiler`, `-top`) are still dropped.

## 2. `FileNotFoundError` on the `.glob` for a `.v` file in the system temp dir

The actual crash in the run:
```
File ".../import_util.py", line 873, in get_glob_contents
    ...
FileNotFoundError: [Errno 2] No such file or directory: '../../../tmp/coqchkminimizer3D8BSnPWc6.glob'
```
…even though the log says coqc *succeeded* and the glob was written. Cause: when the `.v` file is directly in `tempfile.gettempdir()`, `tmp_glob_file` (`gettempdir()/<base>.glob`) and `glob_file` (`<v_file_root>.glob`) are the **same file**. coqc dumps the glob there, the `shutil.move` is a no-op (same file), and then the `finally` cleanup `os.remove(tmp_glob_file)` deletes the only copy — so reading it back fails.

Fix: detect when `tmp_glob_file` and `glob_file` resolve to the same path, and in that case skip both the self-move and the cleanup removal.

## Tests
- `tests/test_coqchk_args.py` — coqchk help parsing + the two-stage arg filter (load-path kept, coqc-only dropped; plus a regression for the empty-help case).
- `tests/test_glob_tmpdir.py` — reproduces the glob deletion with a fake coqc for a `.v` in the temp dir; fails without the fix, passes with it.

All run green locally (`pytest` isn't installed in my env, so I executed the test functions directly).

Context: companion to the runner-side wiring in run-coq-bug-minimizer (rocq-community#53); the runner also relocates the bug file out of `/tmp`, but these fixes make coq-tools robust on its own.