### PR TITLE
Calibrate --chk timeout from combined coqc+coqchk runtime

### DIFF
--- a/coq_tools/diagnose_error.py
+++ b/coq_tools/diagnose_error.py
@@ -705,7 +705,16 @@ def get_coq_output(
         % (returncode, util.s(stdout), util.s(stderr), runtime, peak_rss_kb),
         level=verbose_base + 1,
     )
-    if get_timeout(coqc_prog) is None and timeout_val is not None:
+    # When coqchk is also going to run, defer calibrating the timeout until
+    # after it finishes, so the timeout reflects the combined coqc+coqchk
+    # runtime (see below).  coqchk re-checks the whole transitive closure and is
+    # typically far slower than compiling the file, so a timeout based on coqc
+    # alone would cause every subsequent coqchk run to be killed.
+    if (
+        get_timeout(coqc_prog) is None
+        and timeout_val is not None
+        and coqchk_prog is None
+    ):
         set_timeout(coqc_prog, 3 * max((1, int(math.ceil(finish - start)))), **kwargs)
 
     combined_stdout = util.s(stdout)
@@ -766,6 +775,18 @@ def get_coq_output(
         )
         combined_runtime = runtime + chk_runtime
         combined_peak_rss_kb = max(peak_rss_kb, chk_peak_rss_kb)
+
+    # Calibrate the per-program timeout from the combined coqc+coqchk runtime
+    # when coqchk ran, so coqchk isn't killed on subsequent runs (see the note
+    # where the coqc-only timeout is set above).
+    if (
+        get_timeout(coqc_prog) is None
+        and timeout_val is not None
+        and coqchk_prog is not None
+    ):
+        set_timeout(
+            coqc_prog, 3 * max((1, int(math.ceil(combined_runtime)))), **kwargs
+        )
 
     # Now clean up after coqchk has run (or if coqchk wasn't needed)
     cleaner()


### PR DESCRIPTION
Follow-up to #424. With the load-path and glob fixes in, coqchk now actually runs over the closure — but minimization then aborts with:

```
checking cst:Stdlib.Numbers.NatInt.NZPow.C.mul_le_mono_nonneg
Timeout! (external)
Moving …/bug_01.v to …/tmp.v...
Fatal error: Sanity check failed.
```

### Cause

In `get_coq_output`, the adaptive per-program timeout is set to `3 × coqc runtime`, measured **before** coqchk runs:

```python
finish = time.time()            # right after coqc, before coqchk
if get_timeout(coqc_prog) is None and timeout_val is not None:
    set_timeout(coqc_prog, 3 * max((1, int(math.ceil(finish - start)))), ...)
```

But `--chk` then runs coqchk, which re-checks the file's **entire transitive closure** (all of Stdlib/Bignums/Coqprime) and is far slower than compiling `Require Coqprime.PrimalityTest.Root.`. So the first (untimed) run records a tiny timeout based on coqc alone, and every subsequent run kills coqchk (`Timeout! (external)`) long before it reaches the offending module. The target error never reproduces, so `minimize_file`'s initial sanity check fails (`Fatal error: Sanity check failed.`).

### Fix

When coqchk is enabled, defer calibrating the timeout until after coqchk finishes and base it on the **combined** coqc+coqchk runtime (`combined_runtime`, already computed) instead of coqc alone. The coqc-only calibration is kept for the non-`--chk` path.

The first run is still untimed, so it pays the full closure-check cost once to calibrate — expected and unavoidable.

No automated test: this is timing-dependent behavior and `diagnose_error` can't be imported in my environment (missing `subprocess4`), so a reliable unit test isn't practical. The change is a small, localized adjustment to where/how `set_timeout` is called.

Context: completes the coqchk minimization path for rocq-prover/rocq#22125.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uy4PAeARWFGNgmukKQBLFQ)_